### PR TITLE
x.cuda(async=True) —> x.cuda(non_blocking=True)

### DIFF
--- a/losses/unet.py
+++ b/losses/unet.py
@@ -5,7 +5,7 @@ import numpy as np
 
 
 def cuda(x):
-    return x.cuda(async=True) if torch.cuda.is_available() else x
+    return x.cuda(non_blocking=True) if torch.cuda.is_available() else x
 
 
 class LossBinary:


### PR DESCRIPTION
Fixes #3 The Dockerfiles are pip installing PyTorch=0.4.1 so this change is appropriate to match with https://github.com/pytorch/pytorch/pull/4999  This change should enable compatibility with Python 3.7 and later.