### PR TITLE
moved `prepare_device` to `UtilsFactory`

### DIFF
--- a/dl/utils.py
+++ b/dl/utils.py
@@ -161,8 +161,12 @@ class UtilsFactory:
         return criterion, optimizer, scheduler
 
     @staticmethod
+    def prepare_device():
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    @staticmethod
     def prepare_model(model):
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        device = UtilsFactory.prepare_device()
 
         if torch.cuda.is_available():
             cudnn.benchmark = True


### PR DESCRIPTION
now, for any script you have, you don't repeat `torch.device("cuda" if torch.cuda.is_available() else "cpu")` but use an utility method from `UtilsFactory`.

This is why Catalyst was created for – to prevent writing the same code in `the-loop` 💯 