### PR TITLE
yapf hack to import all callbacks

### DIFF
--- a/.yapfignore
+++ b/.yapfignore
@@ -1,0 +1,1 @@
+contrib/criterion/__init__.py

--- a/.yapfignore
+++ b/.yapfignore
@@ -1,1 +1,1 @@
-contrib/criterion/__init__.py
+catalyst/dl/callbacks/__init__.py

--- a/.yapfignore
+++ b/.yapfignore
@@ -1,1 +1,1 @@
-catalyst/dl/callbacks/__init__.py
+dl/callbacks/__init__.py

--- a/dl/callbacks/__init__.py
+++ b/dl/callbacks/__init__.py
@@ -1,22 +1,10 @@
-from . import core
-from . import metrics
-from . import schedulers
-from .core import Callback, CallbackCompose, Logger, \
-    TensorboardLogger, CheckpointCallback, OptimizerCallback, \
-    SchedulerCallback, ClassificationLossCallback, InferCallback, \
-    MixupCallback, InferMaskCallback
-from .metrics import MetricCallback, MultiMetricCallback, \
-    DiceCallback, JaccardCallback, PrecisionCallback, MapKCallback
-from .schedulers import LRUpdater, OneCycleLR, LRFinder
+from . import core, metrics, schedulers
 
-__all__ = [
-    "Callback", "CallbackCompose", "Logger", "TensorboardLogger",
-    "CheckpointCallback", "OptimizerCallback", "SchedulerCallback",
-    "ClassificationLossCallback", "InferCallback", "MixupCallback",
-    "InferMaskCallback", "MetricCallback", "MultiMetricCallback",
-    "DiceCallback", "JaccardCallback", "PrecisionCallback", "MapKCallback",
-    "LRUpdater", "OneCycleLR", "LRFinder", "CALLBACKS"
-]
+# yapf: disable
+from .core import *
+from .metrics import *
+from .schedulers import *
+# yapf: enable
 
 CALLBACKS = {
     **core.__dict__,

--- a/dl/callbacks/__init__.py
+++ b/dl/callbacks/__init__.py
@@ -1,10 +1,8 @@
 from . import core, metrics, schedulers
 
-# yapf: disable
-from .core import *
-from .metrics import *
-from .schedulers import *
-# yapf: enable
+from .core import *  # yapf: disable
+from .metrics import *  # yapf: disable
+from .schedulers import *  # yapf: disable
 
 CALLBACKS = {
     **core.__dict__,

--- a/dl/callbacks/__init__.py
+++ b/dl/callbacks/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from . import core, metrics, schedulers
 
 from .core import *  # yapf: disable

--- a/dl/callbacks/__init__.py
+++ b/dl/callbacks/__init__.py
@@ -1,9 +1,9 @@
 # flake8: noqa
 from . import core, metrics, schedulers
 
-from .core import *  # yapf: disable
-from .metrics import *  # yapf: disable
-from .schedulers import *  # yapf: disable
+from .core import *
+from .metrics import *
+from .schedulers import *
 
 CALLBACKS = {
     **core.__dict__,


### PR DESCRIPTION
- improved readability 
- all new callbacks will be automatically added to `__init__.py`, it will allow you to use `from catalyst.dl.callbacks import ...`
- no need to change `yapf` config with with hack