### PR TITLE
JSON logging

### DIFF
--- a/catalyst/dl/callbacks/loggers.py
+++ b/catalyst/dl/callbacks/loggers.py
@@ -20,10 +20,11 @@ class TxtMetricsFormatter(logging.Formatter):
             "{}: {:.5f}".format(k, v) for k, v in sorted(metrics.items())
         )
 
-    def _format_metrics_message(self, state):
+    @staticmethod
+    def _format_metrics_message(state):
         message = f"{state.epoch} * Epoch metrics:\n"
         for k, v in sorted(state.epoch_metrics.items()):
-            message += f"({k}) {self._get_metrics_string(v)}\n"
+            message += f"({k}) {TxtMetricsFormatter._get_metrics_string(v)}\n"
         return message
 
     def format(self, record):

--- a/catalyst/dl/callbacks/loggers.py
+++ b/catalyst/dl/callbacks/loggers.py
@@ -10,6 +10,16 @@ from .utils import to_batch_metrics
 
 
 class TxtMetricsFormatter(logging.Formatter):
+    """
+    Translate batch metrics in human-readable format.
+
+    This class is used by logging.Logger to make a string from record.
+    For details refer to official docs for 'logging' module.
+
+    Note:
+        This is inner class used by Logger callback,
+        no need to use it directly!
+    """
 
     def __init__(self):
         fmt = "[{asctime}] {message}"
@@ -34,6 +44,16 @@ class TxtMetricsFormatter(logging.Formatter):
 
 
 class JsonMetricsFormatter(logging.Formatter):
+    """
+    Translate batch metrics in json format.
+
+    This class is used by logging.Logger to make a string from record.
+    For details refer to official docs for 'logging' module.
+
+    Note:
+        This is inner class used by Logger callback,
+        no need to use it directly!
+    """
 
     def __init__(self):
         fmt = "{message}"

--- a/catalyst/dl/callbacks/loggers.py
+++ b/catalyst/dl/callbacks/loggers.py
@@ -41,7 +41,8 @@ class JsonMetricsFormatter(logging.Formatter):
 
     def format(self, record):
         state = record.state
-        dct = state.epoch_metrics.copy()
+        dct = {}
+        dct["epoch_metrics"] = state.epoch_metrics.copy()
         dct["epoch"] = state.epoch
         dct["asctime"] = self.formatTime(record)
         return json.dumps(dct)

--- a/catalyst/dl/callbacks/loggers.py
+++ b/catalyst/dl/callbacks/loggers.py
@@ -8,7 +8,7 @@ from .core import Callback
 from .utils import to_batch_metrics
 
 
-class TXTMetricsFormatter(logging.Formatter):
+class TxtMetricsFormatter(logging.Formatter):
 
     def __init__(self):
         fmt = "[{asctime}] {message}"
@@ -62,7 +62,7 @@ class Logger(Callback):
         fh.setLevel(logging.INFO)
         ch = logging.StreamHandler()
         ch.setLevel(logging.INFO)
-        formatter = TXTMetricsFormatter()
+        formatter = TxtMetricsFormatter()
         fh.setFormatter(formatter)
         ch.setFormatter(formatter)
         # add the handlers to the logger


### PR DESCRIPTION
#86 **WIP but review required**

In order to log in human-readable format and json using single Logger object I move all message formatting logic in separate classes: TXTMetricsFormatter, JSONMetricsFormatter (not yet). And also change a bit output format:

**old:**
```
[2019-01-27 20:05:53,692] 3 * Epoch (train) metrics: base/data_time: 0.00179 | base/batch_time: 0.01806 | base/sample_per_second: 3700.66476 | precision01: 56.65361 | precision03: 85.93350 | precision05: 94.98881 | lr: 0.00091 | momentum: 0.86341 | loss: 1.21355
[2019-01-27 20:05:53,692] 3 * Epoch (valid) metrics: base/data_time: 0.00178 | base/batch_time: 0.01795 | base/sample_per_second: 3846.72703 | precision01: 56.98646 | precision03: 86.35549 | precision05: 95.14331 | lr: 0.00087 | momentum: 0.87007 | loss: 1.20383
[2019-01-27 20:05:53,692] 

[2019-01-27 20:06:30,140] 4 * Epoch (train) metrics: base/data_time: 0.00177 | base/batch_time: 0.01809 | base/sample_per_second: 3717.03478 | precision01: 60.12628 | precision03: 87.78573 | precision05: 95.86197 | lr: 0.00082 | momentum: 0.87676 | loss: 1.12157
[2019-01-27 20:06:30,140] 4 * Epoch (valid) metrics: base/data_time: 0.00168 | base/batch_time: 0.01784 | base/sample_per_second: 3863.66785 | precision01: 60.33041 | precision03: 87.50995 | precision05: 95.78025 | lr: 0.00078 | momentum: 0.88342 | loss: 1.11878
[2019-01-27 20:06:30,141] 
```

**new:**
```
[2019-01-30 01:30:27,347] 3 * Epoch metrics:
(train) accuracy: 0.82522 | base/batch_time: 0.55167 | base/data_time: 0.54046 | base/lr: 0.04031 | base/momentum: 0.90000 | base/sample_per_second: 5478.24425 | loss: 0.39073
(valid) accuracy: 0.81212 | base/batch_time: 0.99874 | base/data_time: 0.99213 | base/lr: 0.04555 | base/momentum: 0.90000 | base/sample_per_second: 5900.37824 | loss: 0.42035

[2019-01-30 01:30:54,863] 4 * Epoch metrics:
(train) accuracy: 0.84485 | base/batch_time: 0.53019 | base/data_time: 0.51835 | base/lr: 0.05180 | base/momentum: 0.90000 | base/sample_per_second: 5698.95703 | loss: 0.36340
(valid) accuracy: 0.84224 | base/batch_time: 1.01936 | base/data_time: 1.01174 | base/lr: 0.05704 | base/momentum: 0.90000 | base/sample_per_second: 5766.57310 | loss: 0.36509

```

Also method Logger.on_train_begin was removed as never used.