### PR TITLE
remove logdir hack in runner

### DIFF
--- a/catalyst/dl/callbacks/loggers.py
+++ b/catalyst/dl/callbacks/loggers.py
@@ -5,7 +5,7 @@ from typing import List, Dict
 
 from catalyst.dl.state import RunnerState
 from catalyst.dl.utils import UtilsFactory
-from .core import Callback
+from .base import LoggerCallback
 from .utils import to_batch_metrics
 
 
@@ -68,7 +68,7 @@ class JsonMetricsFormatter(logging.Formatter):
         return json.dumps(dct)
 
 
-class Logger(Callback):
+class Logger(LoggerCallback):
     """
     Logger callback, translates state.*_metrics to console and text file
     """
@@ -77,18 +77,12 @@ class Logger(Callback):
         """
         :param logdir: log directory to use for text logging
         """
+        super().__init__(logdir)
         self.logger = None
-        self._logdir = logdir
 
-    @property
-    def logdir(self):
-        return self._logdir
-
-    @logdir.setter
-    def logdir(self, value):
-        self._logdir = value
-        os.makedirs(value, exist_ok=True)
-        logger_name = os.path.join(value, "logs")
+    def on_train_start(self, state):
+        super().on_train_start(state)
+        logger_name = os.path.join(self.logdir, "logs")
         self.logger = self._get_logger(logger_name)
 
     @staticmethod
@@ -120,7 +114,7 @@ class Logger(Callback):
             self.logger.info("", extra={"state": state})
 
 
-class TensorboardLogger(Callback):
+class TensorboardLogger(LoggerCallback):
     """
     Logger callback, translates state.*_metrics to tensorboard
     """
@@ -140,7 +134,7 @@ class TensorboardLogger(Callback):
             prepends 'batch_' prefix to their names.
         :param log_on_epoch_end: Logs per-epoch metrics if set True.
         """
-        self.logdir = logdir
+        super().__init__(logdir)
         self.metrics_to_log = metric_names
         self.log_on_batch_end = log_on_batch_end
         self.log_on_epoch_end = log_on_epoch_end

--- a/catalyst/dl/runner.py
+++ b/catalyst/dl/runner.py
@@ -125,10 +125,7 @@ class BaseModelRunner:
 
         state_params = state_params or {}
         state = self._init_state(
-            mode=mode,
-            stage=self.stage,
-            logdir=logdir,
-            **state_params
+            mode=mode, stage=self.stage, logdir=logdir, **state_params
         )
         state.mode = mode
         self.state = state

--- a/catalyst/dl/runner.py
+++ b/catalyst/dl/runner.py
@@ -106,7 +106,8 @@ class BaseModelRunner:
         epochs: int = 1,
         start_epoch: int = 0,
         mode: str = "train",
-        verbose: bool = False
+        verbose: bool = False,
+        logdir: str = None
     ):
         """
         Main method for running train/valid/infer/debug pipeline over model.
@@ -123,7 +124,12 @@ class BaseModelRunner:
         assert isinstance(callbacks, OrderedDict)
 
         state_params = state_params or {}
-        state = self._init_state(mode=mode, stage=self.stage, **state_params)
+        state = self._init_state(
+            mode=mode,
+            stage=self.stage,
+            logdir=logdir,
+            **state_params
+        )
         state.mode = mode
         self.state = state
 
@@ -202,11 +208,6 @@ class BaseModelRunner:
         :param verbose: verbose flag
         :param logdir: logdir for tensorboard logs
         """
-        # @TODO: remove hack
-        if logdir is not None:
-            for key, value in callbacks.items():
-                if hasattr(value, "logdir"):
-                    value.logdir = logdir
         self.run(
             loaders=loaders,
             callbacks=callbacks,
@@ -214,7 +215,8 @@ class BaseModelRunner:
             epochs=epochs,
             start_epoch=start_epoch,
             mode="train",
-            verbose=verbose
+            verbose=verbose,
+            logdir=logdir,
         )
 
     @staticmethod


### PR DESCRIPTION
Add base class for anything that needs 'logdir' to be specified in 'train' mode - LoggerCallback.

'logdir' attribute implicitly added to RunnerState through kwargs (probably, it would be better to add it explicitly).

LoggerCallback becomes base class for CheckpointCallback, Logger, TensorboardLogger.