### PR TITLE
fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
 
 stages:
   - Codestyle
+  - Tests
   - Examples
   - Deploy
 
@@ -42,6 +43,13 @@ jobs:
         - flake8 . --count --exit-zero --max-complexity=10 --statistics
         # test to make sure the code is yapf compliant
         - ./yapf.sh --all
+
+    - stage: Tests
+      install:
+        - *requirements
+        - pip install -U pytest
+      script:
+        - pytest
 
     - stage: Examples
       name: "Examples DL"

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ jobs:
     - stage: Tests
       install:
         - *requirements
+        - pip install seaborn
         - pip install -U pytest
       script:
         - pytest

--- a/catalyst/utils/config.py
+++ b/catalyst/utils/config.py
@@ -50,8 +50,13 @@ def save_config(config, logdir: str) -> None:
 def parse_config_args(*, config, args, unknown_args):
     for arg in unknown_args:
         arg_name, value = arg.split("=")
-        arg_name = arg_name[2:]
-        value_content, value_type = value.rsplit(":", 1)
+        arg_name = arg_name.lstrip("-").strip('/')
+
+        content = value.rsplit(":", 1)
+        if len(content) == 1:
+            value_content, value_type = content[0], "str"
+        else:
+            value_content, value_type = content
 
         if "/" in arg_name:
             arg_names = arg_name.split("/")

--- a/catalyst/utils/config.py
+++ b/catalyst/utils/config.py
@@ -47,14 +47,6 @@ def save_config(config, logdir: str) -> None:
         json.dump(config, fout, indent=2)
 
 
-def set_arg_to_config(config, key, value) -> None:
-    args_exists_ = config.get("args")
-    if args_exists_ is None:
-        config["args"] = dict()
-
-    config["args"][key] = value
-
-
 def parse_config_args(*, config, args, unknown_args):
     for arg in unknown_args:
         arg_name, value = arg.split("=")
@@ -84,8 +76,13 @@ def parse_config_args(*, config, args, unknown_args):
                 arg_value = eval("%s(%s)" % (value_type, value_content))
             args.__setattr__(arg_name, arg_value)
 
+    args_exists_ = config.get("args")
+    if args_exists_ is None:
+        config["args"] = dict()
+
     for key, value in args._get_kwargs():
-        set_arg_to_config(config, key, value)
+        if value is not None:
+            config["args"][key] = value
 
     return config, args
 

--- a/catalyst/utils/config.py
+++ b/catalyst/utils/config.py
@@ -75,6 +75,12 @@ def parse_config_args(*, config, args, unknown_args):
             else:
                 arg_value = eval("%s(%s)" % (value_type, value_content))
             args.__setattr__(arg_name, arg_value)
+
+            args_exists_ = config.get("args")
+            if args_exists_ is None:
+                config["args"] = dict()
+            config["args"][arg_name] = arg_value
+
     return config, args
 
 

--- a/catalyst/utils/config.py
+++ b/catalyst/utils/config.py
@@ -47,7 +47,18 @@ def save_config(config, logdir: str) -> None:
         json.dump(config, fout, indent=2)
 
 
+def set_arg_to_config(config, key, value) -> None:
+    args_exists_ = config.get("args")
+    if args_exists_ is None:
+        config["args"] = dict()
+
+    config["args"][key] = value
+
+
 def parse_config_args(*, config, args, unknown_args):
+    for key, value in args._get_kwargs():
+        set_arg_to_config(config, key, value)
+
     for arg in unknown_args:
         arg_name, value = arg.split("=")
         arg_name = arg_name.lstrip("-").strip('/')
@@ -75,11 +86,7 @@ def parse_config_args(*, config, args, unknown_args):
             else:
                 arg_value = eval("%s(%s)" % (value_type, value_content))
             args.__setattr__(arg_name, arg_value)
-
-            args_exists_ = config.get("args")
-            if args_exists_ is None:
-                config["args"] = dict()
-            config["args"][arg_name] = arg_value
+            set_arg_to_config(config, arg_name, arg_value)
 
     return config, args
 

--- a/catalyst/utils/config.py
+++ b/catalyst/utils/config.py
@@ -52,11 +52,7 @@ def parse_config_args(*, config, args, unknown_args):
         arg_name, value = arg.split("=")
         arg_name = arg_name.lstrip("-").strip('/')
 
-        content = value.rsplit(":", 1)
-        if len(content) == 1:
-            value_content, value_type = content[0], "str"
-        else:
-            value_content, value_type = content
+        value_content, value_type = value.rsplit(":", 1)
 
         if "/" in arg_name:
             arg_names = arg_name.split("/")

--- a/catalyst/utils/config.py
+++ b/catalyst/utils/config.py
@@ -56,9 +56,6 @@ def set_arg_to_config(config, key, value) -> None:
 
 
 def parse_config_args(*, config, args, unknown_args):
-    for key, value in args._get_kwargs():
-        set_arg_to_config(config, key, value)
-
     for arg in unknown_args:
         arg_name, value = arg.split("=")
         arg_name = arg_name.lstrip("-").strip('/')
@@ -86,7 +83,9 @@ def parse_config_args(*, config, args, unknown_args):
             else:
                 arg_value = eval("%s(%s)" % (value_type, value_content))
             args.__setattr__(arg_name, arg_value)
-            set_arg_to_config(config, arg_name, arg_value)
+
+    for key, value in args._get_kwargs():
+        set_arg_to_config(config, key, value)
 
     return config, args
 

--- a/catalyst/utils/tests/test_config.py
+++ b/catalyst/utils/tests/test_config.py
@@ -6,20 +6,29 @@ from .. import config
 
 def test_parse_config_args():
     configuration = {
-        "stages": {"one": "uno", "two": "dos", "three": "tres"},
-        "key": {"value": "key2"}
+        "stages": {
+            "one": "uno",
+            "two": "dos",
+            "three": "tres"
+        },
+        "key": {
+            "value": "key2"
+        }
     }
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--command")
 
-    args, uargs = parser.parse_known_args([
-        "--command", "train",
-        "--path=test.yml:str",
-        "--stages/zero=cero:str"
-    ])
+    args, uargs = parser.parse_known_args(
+        [
+            "--command", "train", "--path=test.yml:str",
+            "--stages/zero=cero:str"
+        ]
+    )
 
-    configuration, args = config.parse_config_args(config=configuration, args=args, unknown_args=uargs)
+    configuration, args = config.parse_config_args(
+        config=configuration, args=args, unknown_args=uargs
+    )
     assert args.command == "train"
     assert args.path == "test.yml"
     assert configuration.get("stages") is not None

--- a/catalyst/utils/tests/test_config.py
+++ b/catalyst/utils/tests/test_config.py
@@ -23,15 +23,19 @@ def test_parse_config_args():
     args, uargs = parser.parse_known_args(
         [
             "--command", "train", "--path=test.yml:str",
-            "--stages/zero=cero:str"
+            "--stages/zero=cero:str", "-C=like:str"
         ]
     )
 
     configuration, args = config.parse_config_args(
         config=configuration, args=args, unknown_args=uargs
     )
+
     assert args.command == "train"
     assert args.path == "test.yml"
     assert configuration.get("stages") is not None
     assert "zero" in configuration["stages"]
     assert configuration["stages"]["zero"] == "cero"
+    assert configuration.get("args") is not None
+    assert configuration["args"]["path"] == "test.yml"
+    assert configuration["args"]["C"] == "like"

--- a/catalyst/utils/tests/test_config.py
+++ b/catalyst/utils/tests/test_config.py
@@ -20,7 +20,7 @@ def test_parse_config_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--command")
 
-    _args, uargs = parser.parse_known_args(
+    args, uargs = parser.parse_known_args(
         [
             "--command", "train", "--path=test.yml:str",
             "--stages/zero=cero:str", "-C=like:str"
@@ -28,7 +28,7 @@ def test_parse_config_args():
     )
 
     configuration, args = config.parse_config_args(
-        config=configuration, args=_args, unknown_args=uargs
+        config=configuration, args=args, unknown_args=uargs
     )
 
     assert args.command == "train"
@@ -41,7 +41,7 @@ def test_parse_config_args():
     assert configuration["args"]["C"] == "like"
     assert configuration["args"]["command"] == "train"
 
-    for key, value in _args._get_kwargs():
+    for key, value in args._get_kwargs():
         v = configuration["args"].get(key)
         assert v is not None
         assert v == value

--- a/catalyst/utils/tests/test_config.py
+++ b/catalyst/utils/tests/test_config.py
@@ -1,0 +1,27 @@
+import argparse
+import pytest
+
+from .. import config
+
+
+def test_parse_config_args():
+    configuration = {
+        "stages": {"one": "uno", "two": "dos", "three": "tres"},
+        "key": {"value": "key2"}
+    }
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--command")
+
+    args, uargs = parser.parse_known_args([
+        "--command", "train",
+        "--path=test.yml:str",
+        "--stages/zero=cero:str"
+    ])
+
+    configuration, args = config.parse_config_args(config=configuration, args=args, unknown_args=uargs)
+    assert args.command == "train"
+    assert args.path == "test.yml"
+    assert configuration.get("stages") is not None
+    assert "zero" in configuration["stages"]
+    assert configuration["stages"]["zero"] == "cero"

--- a/catalyst/utils/tests/test_config.py
+++ b/catalyst/utils/tests/test_config.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 import argparse
 import pytest
 

--- a/catalyst/utils/tests/test_config.py
+++ b/catalyst/utils/tests/test_config.py
@@ -39,3 +39,4 @@ def test_parse_config_args():
     assert configuration.get("args") is not None
     assert configuration["args"]["path"] == "test.yml"
     assert configuration["args"]["C"] == "like"
+    assert configuration["args"]["command"] == "train"

--- a/catalyst/utils/tests/test_config.py
+++ b/catalyst/utils/tests/test_config.py
@@ -20,7 +20,7 @@ def test_parse_config_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--command")
 
-    args, uargs = parser.parse_known_args(
+    _args, uargs = parser.parse_known_args(
         [
             "--command", "train", "--path=test.yml:str",
             "--stages/zero=cero:str", "-C=like:str"
@@ -28,7 +28,7 @@ def test_parse_config_args():
     )
 
     configuration, args = config.parse_config_args(
-        config=configuration, args=args, unknown_args=uargs
+        config=configuration, args=_args, unknown_args=uargs
     )
 
     assert args.command == "train"
@@ -40,3 +40,8 @@ def test_parse_config_args():
     assert configuration["args"]["path"] == "test.yml"
     assert configuration["args"]["C"] == "like"
     assert configuration["args"]["command"] == "train"
+
+    for key, value in _args._get_kwargs():
+        v = configuration["args"].get(key)
+        assert v is not None
+        assert v == value


### PR DESCRIPTION
- support for not only `--long-keys` but also for shorts `-S`
- if the type is not written explicitly then the parser will use `str` by default (`--key:str` == `--key`)
- fixed error, when slashes at edge produce empty keys. Previously, `--deep/key//=12:int` returns 
```
'deep': {'key': {'': {'': 12}}
```

now it's simply 
```
'deep': {'key': 12}
```