### PR TITLE
Fixes #118

### DIFF
--- a/catalyst/contrib/scripts/tag2label.py
+++ b/catalyst/contrib/scripts/tag2label.py
@@ -17,20 +17,22 @@ def prepare_df_from_dirs(in_dirs, tag_column_name):
         else:
             # leaves last part of in_dir path,
             #  which identifies separate in_dir
-            return x.replace(f"{in_dir}",
-                             f"{in_dir.split('/')[-2]}/")
+            return x.replace(
+                f"{in_dir}",
+                f"{in_dir.split('/')[-2]}/")
 
     for in_dir in splitted_dirs:
         if not in_dir.endswith("/"):
             in_dir = f"{in_dir}/"
 
-        dataset = create_dataset(f"{in_dir}/**",
-                                 process_fn=process_fn)
+        dataset = create_dataset(
+            f"{in_dir}/**",
+            process_fn=process_fn)
 
-        dfs.append(create_dataframe(dataset,
-                                    columns=[tag_column_name,
-                                             "filepath"])
-                   )
+        dfs.append(
+            create_dataframe(
+                dataset,
+                columns=[tag_column_name, "filepath"]))
 
     df = pd.concat(dfs).reset_index(drop=True)
     return df

--- a/catalyst/contrib/scripts/tests/test_tag2label.py
+++ b/catalyst/contrib/scripts/tests/test_tag2label.py
@@ -1,0 +1,69 @@
+import shutil
+from pathlib import Path
+from ..tag2label import prepare_df_from_dirs
+
+
+def prepare_dataset():
+    shutil.rmtree('datasets', ignore_errors=True)
+
+    # dummy datasets e.g. root1 and root2
+    root1 = Path('datasets/root1')
+    root1.mkdir(parents=True, exist_ok=True)
+    root2 = Path('datasets/root2')
+    root2.mkdir(parents=True, exist_ok=True)
+
+    # dummy labels folders for root1
+    root1_act1 = root1 / 'act1'
+    root1_act2 = root1 / 'act2'
+    root1_act1.mkdir()
+    root1_act2.mkdir()
+
+    # dummy labels folders for root2
+    root2_act1 = root2 / 'act1'
+    root2_act2 = root2 / 'act2'
+    root2_act1.mkdir()
+    root2_act2.mkdir()
+
+    # dummy files for root1
+    a = root1_act1 / 'a.txt'
+    b = root1_act1 / 'b.txt'
+    c = root1_act2 / 'c.txt'
+
+    # dummy files for root2
+    d = root2_act1 / 'd.txt'
+    e = root2_act2 / 'e.txt'
+    f = root2_act2 / 'f.txt'
+
+    for file in [a, b, c, d, e, f]:
+        file.touch()
+
+
+def test_prepare_df_from_dirs_one():
+    def check_filepath(f):
+        return f.startswith('act1') or f.startswith('act2')
+
+    prepare_dataset()
+    df = prepare_df_from_dirs('datasets/root1', 'label')
+
+    assert df.shape[0] == 3
+    assert df.filepath.apply(check_filepath).sum().all()
+    assert df.label.isin(['act1', 'act2']).all()
+
+    shutil.rmtree('datasets', ignore_errors=True)
+
+
+def test_prepare_df_from_dirs_multi():
+    def check_filepath(f):
+        return f.startswith('root1/act1') or \
+               f.startswith('root1/act2') or \
+               f.startswith('root2/act1') or \
+               f.startswith('root2/act2')
+
+    prepare_dataset()
+    df = prepare_df_from_dirs('datasets/root1,datasets/root2',
+                              'label')
+    assert df.shape[0] == 6
+    assert df.filepath.apply(check_filepath).sum().all()
+    assert df.label.isin(['act1', 'act2']).all()
+
+    shutil.rmtree('datasets', ignore_errors=True)

--- a/catalyst/contrib/scripts/tests/test_tag2label.py
+++ b/catalyst/contrib/scripts/tests/test_tag2label.py
@@ -60,8 +60,9 @@ def test_prepare_df_from_dirs_multi():
                f.startswith('root2/act2')
 
     prepare_dataset()
-    df = prepare_df_from_dirs('datasets/root1,datasets/root2',
-                              'label')
+    df = prepare_df_from_dirs(
+        'datasets/root1,datasets/root2',
+        'label')
     assert df.shape[0] == 6
     assert df.filepath.apply(check_filepath).sum().all()
     assert df.label.isin(['act1', 'act2']).all()


### PR DESCRIPTION
New feature add possibility to use multiple path for in-dir parameter in [tag2label](https://github.com/catalyst-team/catalyst/blob/master/catalyst/contrib/scripts/tag2label.py). Old code works as usual. But now you can call:
```catalyst-data tag2label \
    --in-dir=my_datasets/dataset1,my_datasets/dataset2 \
    --out-dataset=dataset.csv \
    --out-labeling=labeling.json \
    --tag-column=label
```
Main attention on comma in `--in-dir=my_datasets/dataset1,my_datasets/dataset2`. In this case `filepath` column in dataset.csv will look like:
`dataset1/class_0/sample_1` 

And if you use one path (`--in-dir=my_datasets/dataset1`), then dataset.csv will look like:
`class_0/sample_1` (like before)

It is useful then you have different parts (or version) of data and want to create combined dataset from this combinations.
