### PR TITLE
registry_as_mapping

### DIFF
--- a/catalyst/rl/random_process.py
+++ b/catalyst/rl/random_process.py
@@ -82,11 +82,10 @@ class OrnsteinUhlenbeckProcess(AnnealedGaussianProcess):
         self.reset_states()
 
     def sample(self):
-        x = (
-            self.x_prev + self.theta * (self.mu - self.x_prev) * self.dt +
-            self.current_sigma * np.sqrt(self.dt
-                                         ) * np.random.normal(size=self.size)
-        )
+        theta = self.theta * (self.mu - self.x_prev)
+        sqrt = np.sqrt(self.dt) * np.random.normal(size=self.size)
+        x = self.x_prev + theta * self.dt + self.current_sigma * sqrt
+
         self.x_prev = x
         self.n_steps += 1
         return x

--- a/catalyst/utils/registry.py
+++ b/catalyst/utils/registry.py
@@ -1,6 +1,6 @@
 import warnings
 from typing import Dict, Callable, Any, Union, Type, Mapping, Tuple, List, \
-    Optional
+    Optional, Iterator
 
 Factory = Union[Type, Callable[..., Any]]
 LateAddCallbak = Callable[["Registry"], None]
@@ -16,7 +16,7 @@ class RegistryException(Exception):
         super().__init__(message)
 
 
-class Registry:
+class Registry(Mapping):
     """
     Universal class allowing to add and access various factories by name
     """
@@ -200,5 +200,39 @@ class Registry:
         if name:
             return self.get_instance(name, meta_factory=meta_factory, **kwargs)
 
+    def all(self) -> List[str]:
+        """
+        :return: list of names of registered items
+        """
+        self._do_late_add()
+        result = list(self._factories.keys())
 
-__all__ = ["Registry"]
+        return result
+
+    def len(self) -> int:
+        """
+        :return: length of registered items
+        """
+        return len(self._factories)
+
+    # mapping methods
+    def __len__(self) -> int:
+        self._do_late_add()
+        return self.len()
+
+    def __getitem__(self, name: str) -> Optional[Factory]:
+        return self.get(name)
+
+    def __iter__(self) -> Iterator[str]:
+        self._do_late_add()
+        return self._factories.__iter__()
+
+    def __contains__(self, name: str):
+        self._do_late_add()
+        return self._factories.__contains__(name)
+
+    def __setitem__(self, name: str, factory: Factory) -> None:
+        self.add(factory, name=name)
+
+
+__all__ = ["Registry", "RegistryException"]


### PR DESCRIPTION
Implement python's mapping methods for Registry class

Examples:
```python
>>> from catalyst.dl import registry

>>> "LinkNet" in registry.MODELS()
True

>>> registry.MODELS().all()
['UNet', 'ResNetUnet', 'LinkNet']

>>> [name for name in registry.CALLBACKS if "LR" in name]
['LRUpdater', 'OneCycleLR', 'LRFinder']

>>> len(registry.CALLBACKS)
71
```