### PR TITLE
for CRITERION import only losses

### DIFF
--- a/catalyst/contrib/criterion/__init__.py
+++ b/catalyst/contrib/criterion/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-from torch.nn import *
+from torch.nn.modules.loss import *
 from .bcece import *
 from .ce import *
 from .center_loss import *


### PR DESCRIPTION

Now only Losses
```python
>>> from catalyst.dl import registry
>>> registry.CRITERIONS

['Module', 'Sequential', 'LogSoftmax', 'weak_module', 'weak_script_method', 'L1Loss', 'NLLLoss', 'NLLLoss2d', 'PoissonNLLLoss', 'KLDivLoss', 'MSELoss', 'BCELoss', 'BCEWithLogitsLoss', 'HingeEmbeddingLoss', 'MultiLabelMarginLoss', 'SmoothL1Loss', 'SoftMarginLoss', 'CrossEntropyLoss', 'MultiLabelSoftMarginLoss', 'CosineEmbeddingLoss', 'MarginRankingLoss', 'MultiMarginLoss', 'TripletMarginLoss', 'CTCLoss', 'BCESoftmaxLoss', 'NaiveCrossEntropyLoss', 'Variable', 'Function', 'CenterLoss', 'CenterLossFunc', 'ContrastiveEmbeddingLoss', 'ContrastiveDistanceLoss', 'BCEDiceLoss', 'DiceLoss', 'FocalLoss', 'HuberLoss', 'LossBinary', 'LossMulti']
```


before:
```python
>>> from catalyst.dl import registry
>>> registry.CRITERIONS
['Module', 'Linear', 'Conv1d', 'Conv2d', 'Conv3d', 'ConvTranspose1d', 'ConvTranspose2d', 'ConvTranspose3d', 'Threshold', 'ReLU', 'Hardtanh', 'ReLU6', 'Sigmoid', 'Tanh', 'Softmax', 'Softmax2d', 'LogSoftmax', 'ELU', 'SELU', 'CELU', 'GLU', 'Hardshrink', 'LeakyReLU', 'LogSigmoid', 'Softplus', 'Softshrink', 'PReLU', 'Softsign', 'Softmin', 'Tanhshrink', 'RReLU', 'L1Loss', 'NLLLoss', 'KLDivLoss', 'MSELoss', 'BCELoss', 'BCEWithLogitsLoss', 'NLLLoss2d', 'PoissonNLLLoss', 'CosineEmbeddingLoss', 'CTCLoss', 'HingeEmbeddingLoss', 'MarginRankingLoss', 'MultiLabelMarginLoss', 'MultiLabelSoftMarginLoss', 'MultiMarginLoss', 'SmoothL1Loss', 'SoftMarginLoss', 'CrossEntropyLoss', 'Container', 'Sequential', 'ModuleList', 'ModuleDict', 'ParameterList', 'ParameterDict', 'AvgPool1d', 'AvgPool2d', 'AvgPool3d', 'MaxPool1d', 'MaxPool2d', 'MaxPool3d', 'MaxUnpool1d', 'MaxUnpool2d', 'MaxUnpool3d', 'FractionalMaxPool2d', 'LPPool1d', 'LPPool2d', 'LocalResponseNorm', 'BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d', 'InstanceNorm1d', 'InstanceNorm2d', 'InstanceNorm3d', 'LayerNorm', 'GroupNorm', 'Dropout', 'Dropout2d', 'Dropout3d', 'AlphaDropout', 'FeatureAlphaDropout', 'ReflectionPad1d', 'ReflectionPad2d', 'ReplicationPad2d', 'ReplicationPad1d', 'ReplicationPad3d', 'CrossMapLRN2d', 'Embedding', 'EmbeddingBag', 'RNNBase', 'RNN', 'LSTM', 'GRU', 'RNNCellBase', 'RNNCell', 'LSTMCell', 'GRUCell', 'PixelShuffle', 'Upsample', 'UpsamplingNearest2d', 'UpsamplingBilinear2d', 'PairwiseDistance', 'AdaptiveMaxPool1d', 'AdaptiveMaxPool2d', 'AdaptiveMaxPool3d', 'AdaptiveAvgPool1d', 'AdaptiveAvgPool2d', 'AdaptiveAvgPool3d', 'TripletMarginLoss', 'ZeroPad2d', 'ConstantPad1d', 'ConstantPad2d', 'ConstantPad3d', 'Bilinear', 'CosineSimilarity', 'Unfold', 'Fold', 'AdaptiveLogSoftmaxWithLoss', 'Parameter', 'DataParallel', 'BCESoftmaxLoss', 'NaiveCrossEntropyLoss', 'Variable', 'Function', 'CenterLoss', 'CenterLossFunc', 'ContrastiveEmbeddingLoss', 'ContrastiveDistanceLoss', 'BCEDiceLoss', 'DiceLoss', 'FocalLoss', 'HuberLoss', 'LossBinary', 'LossMulti']
```