### PR TITLE
Better config cli arg parsing

### DIFF
--- a/catalyst/dl/scripts/run.py
+++ b/catalyst/dl/scripts/run.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
+from argparse import ArgumentParser
 from pathlib import Path
 
 from catalyst.utils.config import parse_args_uargs, dump_config
@@ -8,11 +9,15 @@ from catalyst.utils.misc import set_global_seed, boolean_flag
 from catalyst.dl.scripts.utils import import_experiment_and_runner, dump_code
 
 
-def build_args(parser):
+def build_args(parser: ArgumentParser):
     parser.add_argument(
-        "-C",
         "--config",
+        "--configs",
+        "-C",
+        nargs="+",
         help="path to config/configs",
+        metavar="CONFIG_PATH",
+        dest="configs",
         required=True
     )
     parser.add_argument("--expdir", type=str, default=None)
@@ -66,7 +71,7 @@ def main(args, unknown_args):
     runner = Runner()
 
     if experiment.logdir is not None:
-        dump_config(args.config, experiment.logdir)
+        dump_config(args.configs, experiment.logdir)
         dump_code(args.expdir, experiment.logdir)
 
     runner.run_experiment(

--- a/catalyst/dl/tests/test_main.py
+++ b/catalyst/dl/tests/test_main.py
@@ -1,9 +1,9 @@
-from .. import __main__ as main
-
 import pytest
 
+from .. import __main__ as main
 
-def test_arg_parser_train():
+
+def test_arg_parser_run():
     parser = main.build_parser()
 
     args, uargs = parser.parse_known_args([
@@ -13,22 +13,19 @@ def test_arg_parser_train():
     ])
 
     assert args.command == 'run'
-    assert args.config == 'test.yml'
+    assert args.configs == ['test.yml']
     assert '--unknown' in uargs
 
 
-def test_arg_parser_infer():
+def test_run_multiple_configs():
     parser = main.build_parser()
 
     args, uargs = parser.parse_known_args([
         'run',
-        '--config', 'test.yml',
-        '--unknown'
+        '--config', 'test.yml', 'test1.yml'
     ])
 
-    assert args.command == 'run'
-    assert args.config == 'test.yml'
-    assert '--unknown' in uargs
+    assert args.configs == ['test.yml', 'test1.yml']
 
 
 def test_arg_parser_fail_on_none():

--- a/catalyst/rl/offpolicy/scripts/run_samplers.py
+++ b/catalyst/rl/offpolicy/scripts/run_samplers.py
@@ -5,6 +5,7 @@ import copy
 import atexit
 import argparse
 import multiprocessing as mp
+
 import torch
 
 from catalyst.dl.scripts.utils import import_module
@@ -21,9 +22,13 @@ torch.set_num_threads(1)
 
 def build_args(parser):
     parser.add_argument(
-        "-C",
         "--config",
+        "--configs",
+        "-C",
+        nargs="+",
         help="path to config/configs",
+        metavar="CONFIG_PATH",
+        dest="configs",
         required=True
     )
     parser.add_argument("--expdir", type=str, default=None)

--- a/catalyst/rl/offpolicy/scripts/run_trainer.py
+++ b/catalyst/rl/offpolicy/scripts/run_trainer.py
@@ -4,7 +4,6 @@ import os
 import atexit
 import argparse
 
-
 from catalyst.dl.scripts.utils import import_module
 from catalyst.rl.registry import ALGORITHMS, ENVIRONMENTS
 from catalyst.rl.offpolicy.trainer import Trainer
@@ -15,9 +14,13 @@ from catalyst.utils.misc import set_global_seed
 
 def build_args(parser):
     parser.add_argument(
-        "-C",
         "--config",
+        "--configs",
+        "-C",
+        nargs="+",
         help="path to config/configs",
+        metavar="CONFIG_PATH",
+        dest="configs",
         required=True
     )
     parser.add_argument("--expdir", type=str, default=None)
@@ -41,7 +44,7 @@ def main(args, unknown_args):
 
     if args.logdir is not None:
         os.makedirs(args.logdir, exist_ok=True)
-        dump_config(args.config, args.logdir)
+        dump_config(args.configs, args.logdir)
 
     if args.expdir is not None:
         module = import_module(expdir=args.expdir)  # noqa: F841

--- a/catalyst/utils/config.py
+++ b/catalyst/utils/config.py
@@ -1,9 +1,11 @@
 import os
 import json
-import yaml
 import copy
 import shutil
 from collections import OrderedDict
+
+import yaml
+
 from catalyst.utils.misc import merge_dicts
 
 
@@ -47,7 +49,7 @@ def dump_config(config_path: str, logdir: str) -> None:
     os.makedirs(config_dir, exist_ok=True)
 
     config = {}
-    for config_path_in in config_path.split(","):
+    for config_path_in in config_path:
         config_name = config_path_in.rsplit("/", 1)[-1]
         config_path_out = f"{config_dir}/{config_name}"
         shutil.copyfile(config_path_in, config_path_out)
@@ -125,7 +127,7 @@ def parse_args_uargs(args, unknown_args):
 
     # load params
     config = {}
-    for config_path in args_.config.split(","):
+    for config_path in args_.configs:
         with open(config_path, "r") as fin:
             if config_path.endswith("json"):
                 config_ = json.load(fin, object_pairs_hook=OrderedDict)


### PR DESCRIPTION
Was:
`... --config="./src/segmentator/configs/fieldnet/common.yml,./src/segmentator/configs/fieldnet/train.yml"  ...`
Now:
`... --config ./src/segmentator/configs/fieldnet/common.yml ./src/segmentator/configs/fieldnet/train.yml  ...`
Why:
Former format forced our code to split args manually by comma, which is not always correct, and also breaks autocomplete in shell.