### PR TITLE
Refactor test_tag2label with tmp_path usage

### DIFF
--- a/catalyst/contrib/scripts/tests/test_tag2label.py
+++ b/catalyst/contrib/scripts/tests/test_tag2label.py
@@ -2,14 +2,14 @@ from ..tag2label import prepare_df_from_dirs
 
 
 def _setup_dataset_fs(tmp_path):
-    def create_children(p, children):
-        for c, sub_children in children.items():
-            parent = p/c
-            parent.mkdir()
+    def create_children(parent, children):
+        for child, sub_children in children.items():
+            sub_parent = parent/child
+            sub_parent.mkdir()
             if type(sub_children) == list:
-                [(parent/f).touch() for f in sub_children]
+                [(sub_parent/sub_child).touch() for sub_child in sub_children]
             else:
-                create_children(parent, sub_children)
+                create_children(sub_parent, sub_children)
 
     fs_structure = {
         'datasets': {
@@ -28,8 +28,8 @@ def _setup_dataset_fs(tmp_path):
 
 
 def test_prepare_df_from_dirs_one(tmp_path):
-    def check_filepath(f):
-        return f.startswith('act1') or f.startswith('act2')
+    def check_filepath(filepath):
+        return filepath.startswith('act1') or filepath.startswith('act2')
 
     _setup_dataset_fs(tmp_path)
     root_path = tmp_path/'datasets/root1'
@@ -41,11 +41,11 @@ def test_prepare_df_from_dirs_one(tmp_path):
 
 
 def test_prepare_df_from_dirs_multi(tmp_path):
-    def check_filepath(f):
-        return f.startswith('root1/act1') or \
-               f.startswith('root1/act2') or \
-               f.startswith('root2/act1') or \
-               f.startswith('root2/act2')
+    def check_filepath(filepath):
+        return filepath.startswith('root1/act1') or \
+               filepath.startswith('root1/act2') or \
+               filepath.startswith('root2/act1') or \
+               filepath.startswith('root2/act2')
 
     _setup_dataset_fs(tmp_path)
     ds_path = tmp_path/'datasets'

--- a/catalyst/contrib/scripts/tests/test_tag2label.py
+++ b/catalyst/contrib/scripts/tests/test_tag2label.py
@@ -1,70 +1,57 @@
-import shutil
-from pathlib import Path
 from ..tag2label import prepare_df_from_dirs
 
 
-def prepare_dataset():
-    shutil.rmtree('datasets', ignore_errors=True)
+def _setup_dataset_fs(tmp_path):
+    def create_children(p, children):
+        for c, sub_children in children.items():
+            parent = p/c
+            parent.mkdir()
+            if type(sub_children) == list:
+                [(parent/f).touch() for f in sub_children]
+            else:
+                create_children(parent, sub_children)
 
-    # dummy datasets e.g. root1 and root2
-    root1 = Path('datasets/root1')
-    root1.mkdir(parents=True, exist_ok=True)
-    root2 = Path('datasets/root2')
-    root2.mkdir(parents=True, exist_ok=True)
+    fs_structure = {
+        'datasets': {
+            'root1': {
+                'act1': ['a.txt', 'b.txt'],
+                'act2': ['c.txt']
+            },
+            'root2': {
+                'act1': ['d.txt'],
+                'act2': ['e.txt', 'f.txt']
+            },
+        }
+    }
 
-    # dummy labels folders for root1
-    root1_act1 = root1 / 'act1'
-    root1_act2 = root1 / 'act2'
-    root1_act1.mkdir()
-    root1_act2.mkdir()
-
-    # dummy labels folders for root2
-    root2_act1 = root2 / 'act1'
-    root2_act2 = root2 / 'act2'
-    root2_act1.mkdir()
-    root2_act2.mkdir()
-
-    # dummy files for root1
-    a = root1_act1 / 'a.txt'
-    b = root1_act1 / 'b.txt'
-    c = root1_act2 / 'c.txt'
-
-    # dummy files for root2
-    d = root2_act1 / 'd.txt'
-    e = root2_act2 / 'e.txt'
-    f = root2_act2 / 'f.txt'
-
-    for file in [a, b, c, d, e, f]:
-        file.touch()
+    create_children(tmp_path, fs_structure)
 
 
-def test_prepare_df_from_dirs_one():
+def test_prepare_df_from_dirs_one(tmp_path):
     def check_filepath(f):
         return f.startswith('act1') or f.startswith('act2')
 
-    prepare_dataset()
-    df = prepare_df_from_dirs('datasets/root1', 'label')
+    _setup_dataset_fs(tmp_path)
+    root_path = tmp_path/'datasets/root1'
+    df = prepare_df_from_dirs(str(root_path), 'label')
 
     assert df.shape[0] == 3
     assert df.filepath.apply(check_filepath).sum().all()
     assert df.label.isin(['act1', 'act2']).all()
 
-    shutil.rmtree('datasets', ignore_errors=True)
 
-
-def test_prepare_df_from_dirs_multi():
+def test_prepare_df_from_dirs_multi(tmp_path):
     def check_filepath(f):
         return f.startswith('root1/act1') or \
                f.startswith('root1/act2') or \
                f.startswith('root2/act1') or \
                f.startswith('root2/act2')
 
-    prepare_dataset()
-    df = prepare_df_from_dirs(
-        'datasets/root1,datasets/root2',
-        'label')
+    _setup_dataset_fs(tmp_path)
+    ds_path = tmp_path/'datasets'
+    root_paths = ','.join([str(ds_path/'root1'), str(ds_path/'root2')])
+    df = prepare_df_from_dirs(root_paths, 'label')
+
     assert df.shape[0] == 6
     assert df.filepath.apply(check_filepath).sum().all()
     assert df.label.isin(['act1', 'act2']).all()
-
-    shutil.rmtree('datasets', ignore_errors=True)


### PR DESCRIPTION
I planned to continue writing tests for utils/data but its `create_dataset` method brought me to this test. I think that dummy data should be, if possible, encapsulated -- so here I propose to use `tmp_path` fixture which according to pytest docs will provide unique tmp dir path for every test case. Also I tried to simplify setup code and removed excess library imports. 