### PR TITLE
Parse Tensorboard logs without importing tensorflow (#130)

### DIFF
--- a/catalyst/contrib/scripts/project_embeddings.py
+++ b/catalyst/contrib/scripts/project_embeddings.py
@@ -1,33 +1,30 @@
 import argparse
+import os
+from os import path
+
+import cv2
 import numpy as np
 import pandas as pd
-import os
-import cv2
-import tensorflow as tf
-from tensorflow.contrib.tensorboard.plugins.projector import \
-    visualize_embeddings, ProjectorConfig
-from os import path
+import torch
+from tensorboardX import SummaryWriter
 
 
 def build_args(parser):
     parser.add_argument(
         "--in-npy",
         type=str,
-        dest="in_npy",
         help="path to npy with project embeddings",
         required=True
     )
     parser.add_argument(
         "--in-csv",
         type=str,
-        dest="in_csv",
         help="path to csv with photos",
         required=True
     )
     parser.add_argument(
         "--out-dir",
         type=str,
-        dest="out_dir",
         default=None,
         help="directory to output files",
         required=True
@@ -35,7 +32,6 @@ def build_args(parser):
     parser.add_argument(
         "--out-prefix",
         type=str,
-        dest="out_prefix",
         default=None,
         help="additional prefix to saved files"
     )
@@ -43,20 +39,17 @@ def build_args(parser):
     parser.add_argument(
         "--img-col",
         type=str,
-        dest="img_col",
         default=None,
         help="column in the table that contains image paths"
     )
     parser.add_argument(
         "--img-datapath",
         type=str,
-        dest="img_datapath",
         help="path to photos directory"
     )
     parser.add_argument(
         "--img-size",
         type=int,
-        dest="img_size",
         default=16,
         help="if --img-col is defined, "
              "then images will be resized to (img-size, img-size, 3)"
@@ -64,7 +57,6 @@ def build_args(parser):
     parser.add_argument(
         "--n-rows",
         type=int,
-        dest="n_rows",
         default=None,
         help="count of rows to use in csv "
              "(if not defined then it will use whole data)"
@@ -72,7 +64,6 @@ def build_args(parser):
     parser.add_argument(
         "--meta-cols",
         type=str,
-        dest="meta_cols",
         default=None,
         help="columns in the table to save, separated by commas"
     )
@@ -87,114 +78,48 @@ def parse_args():
     return args
 
 
-# Taken from: https://github.com/tensorflow/tensorflow/issues/6322
-def images_to_sprite(data):
-    """Creates the sprite image along with any necessary padding
-    Args:
-      data: NxHxW[x3] tensor containing the images.
-    Returns:
-      data: Properly shaped HxWx3 image with any necessary padding.
-    """
-    if len(data.shape) == 3:
-        data = np.tile(data[..., np.newaxis], (1, 1, 1, 3))
-    data = data.astype(np.float32)
-    min = np.min(data.reshape((data.shape[0], -1)), axis=1)
-    data = (data.transpose(1, 2, 3, 0) - min).transpose(3, 0, 1, 2)
-    max = np.max(data.reshape((data.shape[0], -1)), axis=1)
-    data = (data.transpose(1, 2, 3, 0) / max).transpose(3, 0, 1, 2)
-
-    n = int(np.ceil(np.sqrt(data.shape[0])))
-    padding = ((0, n**2 - data.shape[0]), (0, 0),
-               (0, 0)) + ((0, 0), ) * (data.ndim - 3)
-    data = np.pad(data, padding, mode="constant", constant_values=0)
-    # Tile the individual thumbnails into an image.
-    data = data.reshape((n, n) + data.shape[1:]).transpose(
-        (0, 2, 1, 3) + tuple(range(4, data.ndim + 1))
-    )
-    data = data.reshape(
-        (n * data.shape[1], n * data.shape[3]) + data.shape[4:]
-    )
-    data = (data * 255).astype(np.uint8)
-    return data
+def load_image(filename, size):
+    image = cv2.imread(filename)[..., ::-1]
+    image = cv2.resize(image,
+                       (size, size),
+                       interpolation=cv2.INTER_NEAREST)
+    return image
 
 
 def main(args, _=None):
     df = pd.read_csv(args.in_csv)
     os.makedirs(args.out_dir, exist_ok=True)
 
-    meta_file = (
-        f"{args.out_prefix}_meta.tsv"
-        if args.out_prefix is not None else "meta.tsv"
-    )
-    out_meta_file = path.join(args.out_dir, meta_file)
-    args.meta_cols = (
-        None if args.meta_cols is None else args.meta_cols.split(",")
-    )
-    df_meta = (df if args.meta_cols is None else df[args.meta_cols])
-
-    df_meta.to_csv(
-        out_meta_file, sep="\t", index=False, header=len(df_meta.columns) > 1
-    )
+    if args.meta_cols is not None:
+        meta_header = args.meta_cols.split(",")
+    else:
+        meta_header = None
 
     features = np.load(args.in_npy, mmap_mode="r")
 
     if args.n_rows is not None:
-        rows_ids = np.random.choice(
-            np.arange(0, len(features)), size=args.n_rows
-        )
-        features = features[rows_ids, :]
-        df = df.iloc[rows_ids]
+        df = df.sample(n=args.n_rows)
 
     if args.img_col is not None:
-        img_data = np.concatenate(
-            list(map(
-                lambda x: np.expand_dims(
-                    cv2.resize(
-                        cv2.imread(path.join(args.img_datapath, x)),
-                        (args.img_size, args.img_size),
-                        interpolation=cv2.INTER_NEAREST),
-                    0),
-                df[args.img_col].values
-            )),
+        image_names = [path.join(args.img_datapath, name)
+                       for name in df[args.img_col].values]
+        img_data = np.stack(
+            [load_image(name, args.img_size)
+             for name in image_names],
             axis=0)
-        img_data = np.array(img_data).reshape(
-            -1, args.img_size, args.img_size, 3
-        ).astype(np.float32)
-        sprite = images_to_sprite(img_data)
-        cv2.imwrite(path.join(args.out_dir, "sprite.png"), sprite)
+        img_data = img_data.transpose((0, 3, 1, 2)) / 255.0
+        img_data = torch.from_numpy(img_data)
+    else:
+        img_data = None
 
-    print(
-        f"Building Tensorboard Projector metadata "
-        f"for ({len(features)}) vectors: {out_meta_file}"
+    summary_writer = SummaryWriter(args.out_dir)
+    summary_writer.add_embedding(
+        features,
+        metadata=df.values,
+        label_img=img_data,
+        metadata_header=meta_header
     )
 
-    print("Running Tensorflow Session...")
-    sess = tf.InteractiveSession()
-    name = args.out_prefix or "tensors"
-    tf.Variable(features, trainable=False, name=name)
-    sess.run(tf.global_variables_initializer())
-    saver = tf.train.Saver()
-    writer = tf.summary.FileWriter(args.out_dir, sess.graph)
-
-    # Link the embeddings into the config
-    config = ProjectorConfig()
-    embed = config.embeddings.add()
-    embed.tensor_name = name
-    embed.metadata_path = meta_file
-
-    if args.img_col is not None:
-        # embed.sprite.image_path = path.join(args.out_dir, "sprite.png")
-        embed.sprite.image_path = "sprite.png"
-        embed.sprite.single_image_dim.extend(
-            [img_data.shape[1], img_data.shape[1]]
-        )
-
-    # Tell the projector about the configured embeddings and metadata file
-    visualize_embeddings(writer, config)
-
-    # Save session and print run command to the output
-    print("Saving Tensorboard Session...")
-    saver.save(sess, path.join(args.out_dir, f"{name}.ckpt"))
     print(
         f"Done. Run `tensorboard --logdir={args.out_dir}` "
         f"to view in Tensorboard"

--- a/catalyst/utils/plotly.py
+++ b/catalyst/utils/plotly.py
@@ -22,7 +22,7 @@ def get_tensorboard_scalars(
         if step in item.tag and (
             metrics is None or any(m in item.tag for m in metrics)
         ):
-            items[item.tag].append(item.value)
+            items[item.tag].append(item)
     return items
 
 

--- a/catalyst/utils/plotly.py
+++ b/catalyst/utils/plotly.py
@@ -15,7 +15,7 @@ from catalyst.utils.tensorboard import SummaryReader, SummaryItem
 def get_tensorboard_scalars(
     logdir: Union[str, Path], metrics: Optional[List[str]], step: str
 ) -> Dict[str, List]:
-    summary_reader = SummaryReader(logdir, type_filter='scalar')
+    summary_reader = SummaryReader(logdir, types=['scalar'])
 
     items = defaultdict(list)
     for item in summary_reader:

--- a/catalyst/utils/plotly.py
+++ b/catalyst/utils/plotly.py
@@ -19,7 +19,9 @@ def get_tensorboard_scalars(
 
     items = defaultdict(list)
     for item in summary_reader:
-        if step in item.tag and (metrics is None or any(m in item.tag for m in metrics)):
+        if step in item.tag and (
+            metrics is None or any(m in item.tag for m in metrics)
+        ):
             items[item.tag].append(item.value)
     return items
 

--- a/catalyst/utils/tensorboard.py
+++ b/catalyst/utils/tensorboard.py
@@ -106,7 +106,7 @@ class EventsFileReader(Iterable):
             yield event
 
 
-SummaryItem = namedtuple('SummaryItem', ['tag', 'step', 'wall_time', 'value'])
+SummaryItem = namedtuple('SummaryItem', ['tag', 'step', 'wall_time', 'value', 'type'])
 
 
 class SummaryReader(Iterable):
@@ -154,13 +154,16 @@ class SummaryReader(Iterable):
                 tag = value.tag
                 if value.HasField('simple_value'):
                     data = value.simple_value
+                    event_type = 'scalar'
                 elif value.HasField('image'):
                     data = cls._decode_image(value.image.encoded_image_string)
+                    event_type = 'image'
                 else:
                     yield None
                     continue
                 yield SummaryItem(
-                    tag=tag, step=step, wall_time=wall_time, value=data
+                    tag=tag, step=step, wall_time=wall_time,
+                    value=data, type=event_type
                 )
 
     def _check_tag(self, tag: str) -> bool:

--- a/catalyst/utils/tensorboard.py
+++ b/catalyst/utils/tensorboard.py
@@ -211,14 +211,6 @@ class SummaryReader(Iterable):
         """
         return self._tag_filter is None or tag in self._tag_filter
 
-    def _check_type(self, event_type: str) -> bool:
-        """
-        Check if a tag matches the current tag filter
-        :param event_type: A string with type name
-        :return: A boolean value.
-        """
-        return self._types is None or event_type in self._types
-
     def __iter__(self) -> SummaryItem:
         """
         Iterate over events in all the files in the current logdir

--- a/catalyst/utils/tensorboard.py
+++ b/catalyst/utils/tensorboard.py
@@ -158,7 +158,7 @@ class SummaryReader(Iterable):
         :param logdir: A directory with Tensorboard summary data
         :param tag_filter: A list of tags to leave (`None` for all)
         :param types: A list of types to get.
-            Note that only 'scalar' and 'image' types are allowed at the moment.
+            Only 'scalar' and 'image' types are allowed at the moment.
         """
         self._logdir = Path(logdir)
 
@@ -172,7 +172,7 @@ class SummaryReader(Iterable):
         if not all(
             type_name in self._DECODERS.keys() for type_name in self._types
         ):
-            raise ValueError('Invalid type filter')
+            raise ValueError('Invalid type name')
 
     def _decode_events(self, events: Iterable) -> Optional[SummaryItem]:
         """

--- a/catalyst/utils/tensorboard.py
+++ b/catalyst/utils/tensorboard.py
@@ -106,7 +106,9 @@ class EventsFileReader(Iterable):
             yield event
 
 
-SummaryItem = namedtuple('SummaryItem', ['tag', 'step', 'wall_time', 'value', 'type'])
+SummaryItem = namedtuple(
+    'SummaryItem', ['tag', 'step', 'wall_time', 'value', 'type']
+)
 
 
 def _get_scalar(value):
@@ -143,7 +145,8 @@ class SummaryReader(Iterable):
     }
 
     def __init__(
-        self, logdir: Union[str, Path],
+        self,
+        logdir: Union[str, Path],
         tag_filter: Optional[Iterable] = None,
         type_filter: Optional[Iterable] = None
     ):
@@ -157,14 +160,18 @@ class SummaryReader(Iterable):
         self._logdir = Path(logdir)
 
         self._tag_filter = set(tag_filter) if tag_filter is not None else None
-        self._type_filter = set(type_filter) if type_filter is not None else None
+        self._type_filter = set(
+            type_filter
+        ) if type_filter is not None else None
         self._check_type_names()
 
     def _check_type_names(self):
         if self._type_filter is None:
             return
-        if not all(type_name in self._DECODERS.keys()
-                   for type_name in self._type_filter):
+        if not all(
+            type_name in self._DECODERS.keys()
+            for type_name in self._type_filter
+        ):
             raise ValueError('Invalid type filter')
 
     @staticmethod
@@ -197,8 +204,11 @@ class SummaryReader(Iterable):
                     data = decoder(value)
                     if data is not None:
                         yield SummaryItem(
-                            tag=tag, step=step, wall_time=wall_time,
-                            value=data, type=value_type
+                            tag=tag,
+                            step=step,
+                            wall_time=wall_time,
+                            value=data,
+                            type=value_type
                         )
                         break
                 else:
@@ -231,7 +241,6 @@ class SummaryReader(Iterable):
                 reader = EventsFileReader(f)
                 yield from (
                     item for item in self._decode_events(reader)
-                    if item is not None
-                       and self._check_tag(item.tag)
-                       and self._check_type(item.type)
+                    if item is not None and self._check_tag(item.tag)
+                    and self._check_type(item.type)
                 )

--- a/catalyst/utils/tensorboard.py
+++ b/catalyst/utils/tensorboard.py
@@ -1,0 +1,186 @@
+import struct
+from collections import namedtuple
+from collections.abc import Iterable
+from crc32c import crc32 as crc32c
+from pathlib import Path
+from typing import BinaryIO, Union, Optional
+
+import cv2
+import numpy as np
+from tensorboard.compat.proto.event_pb2 import Event
+
+
+def _u32(x):
+    return x & 0xffffffff
+
+
+def _masked_crc32c(data):
+    x = _u32(crc32c(data))
+    return _u32(((x >> 15) | _u32(x << 17)) + 0xa282ead8)
+
+
+class EventReadingError(Exception):
+    """
+    An exception that correspond to an event file reading error
+    """
+    pass
+
+
+class EventsFileReader(Iterable):
+    """
+    An iterator over a Tensorboard events file
+    """
+
+    def __init__(self, events_file: BinaryIO):
+        """
+        Initialize an iterator over an events file
+
+        :param events_file: An opened file-like object.
+        """
+        self._events_file = events_file
+
+    def _read(self, size: int) -> Optional[bytes]:
+        """
+        Read exactly next `size` bytes from the current stream.
+
+        :param size: A size in bytes to be read.
+        :return: A `bytes` object with read data or `None` on EOF.
+        :except: NotImplementedError if the stream is in non-blocking mode.
+        :except: EventReadingError on reading error.
+        """
+        data = self._events_file.read(size)
+        if data is None:
+            raise NotImplementedError(
+                'Reading of a stream in non-blocking mode'
+            )
+        if 0 < len(data) < size:
+            raise EventReadingError(
+                'The size of read data is less than requested size'
+            )
+        if len(data) == 0:
+            return None
+        return data
+
+    def _read_and_check(self, size: int) -> Optional[bytes]:
+        """
+        Read and check data described by a format string.
+
+        :param size: A size in bytes to be read.
+        :return: A decoded number.
+        :except: NotImplementedError if the stream is in non-blocking mode.
+        :except: EventReadingError on reading error.
+        """
+        data = self._read(size)
+        if data is None:
+            return None
+        checksum_size = struct.calcsize('I')
+        checksum = struct.unpack('I', self._read(checksum_size))[0]
+        checksum_computed = _masked_crc32c(data)
+        if checksum != checksum_computed:
+            raise EventReadingError(
+                'Invalid checksum. {checksum} != {crc32}'.format(
+                    checksum=checksum, crc32=checksum_computed
+                )
+            )
+        return data
+
+    def __iter__(self) -> Event:
+        """
+        Iterates over events in the current events file
+
+        :return: An Event object
+        :except: NotImplementedError if the stream is in non-blocking mode.
+        :except: EventReadingError on reading error.
+        """
+        while True:
+            header_size = struct.calcsize('Q')
+            header = self._read_and_check(header_size)
+            if header is None:
+                break
+            event_size = struct.unpack('Q', header)[0]
+            event_raw = self._read_and_check(event_size)
+            if event_raw is None:
+                raise EventReadingError('Unexpected end of events file')
+            event = Event()
+            event.ParseFromString(event_raw)
+            yield event
+
+
+SummaryItem = namedtuple('SummaryItem', ['tag', 'step', 'wall_time', 'value'])
+
+
+class SummaryReader(Iterable):
+    """
+    Iterates over events in all the files in the current logdir.
+    Only scalars and images are supported at the moment.
+    """
+
+    def __init__(
+        self, logdir: Union[str, Path], tag_filter: Optional[Iterable] = None
+    ):
+        """
+        Initalize new summary reader
+        :param logdir: A directory with Tensorboard summary data
+        :param tag_filter: A list of tags to leave (`None` for all)
+        """
+        self._logdir = Path(logdir)
+        self._tag_filter = set(tag_filter) if tag_filter is not None else None
+
+    @staticmethod
+    def _decode_image(encoded_image) -> np.ndarray:
+        """
+        Decode binary image representation to Numpy array
+        :param encoded_image: An encoded image data
+        :return: A Numpy array with an H×W×C image
+        """
+        buf = np.frombuffer(encoded_image, np.uint8)
+        data = cv2.imdecode(buf, cv2.IMREAD_COLOR)
+        return data
+
+    @classmethod
+    def _decode_events(cls, events: Iterable) -> Optional[SummaryItem]:
+        """
+        Convert events to `SummaryItem` instances
+        :param events: An iterable with events objects
+        :return: A generator with decoded events
+            or `None`s if an event can't be decoded
+        """
+        for event in events:
+            if not event.HasField('summary'):
+                yield None
+            step = event.step
+            wall_time = event.wall_time
+            for value in event.summary.value:
+                tag = value.tag
+                if value.HasField('simple_value'):
+                    data = value.simple_value
+                elif value.HasField('image'):
+                    data = cls._decode_image(value.image.encoded_image_string)
+                else:
+                    yield None
+                    continue
+                yield SummaryItem(
+                    tag=tag, step=step, wall_time=wall_time, value=data
+                )
+
+    def _check_tag(self, tag: str) -> bool:
+        """
+        Check if a tag matches the current tag filter
+        :param tag: A string with tag
+        :return: A boolean value.
+        """
+        return self._tag_filter is None or tag in self._tag_filter
+
+    def __iter__(self) -> SummaryItem:
+        """
+        Iterate over events in all the files in the current logdir
+        :return: A generator with `SummaryItem` objects
+        """
+        log_files = sorted(f for f in self._logdir.glob('*') if f.is_file())
+        for file_path in log_files:
+            with open(file_path, 'rb') as f:
+                reader = EventsFileReader(f)
+                yield from (
+                    item for item in self._decode_events(reader)
+                    if item is not None and self._check_tag(item.tag)
+                )

--- a/catalyst/utils/tensorboard.py
+++ b/catalyst/utils/tensorboard.py
@@ -1,13 +1,17 @@
 import struct
 from collections import namedtuple
 from collections.abc import Iterable
-from crc32c import crc32 as crc32c
 from pathlib import Path
 from typing import BinaryIO, Union, Optional
 
 import cv2
 import numpy as np
 from tensorboardX.proto.event_pb2 import Event
+
+import os
+if os.environ.get('CRC32C_SW_MODE', None) is None:
+    os.environ['CRC32C_SW_MODE'] = 'auto'
+from crc32c import crc32 as crc32c  # noqa: E402
 
 
 def _u32(x):

--- a/catalyst/utils/tensorboard.py
+++ b/catalyst/utils/tensorboard.py
@@ -7,7 +7,7 @@ from typing import BinaryIO, Union, Optional
 
 import cv2
 import numpy as np
-from tensorboard.compat.proto.event_pb2 import Event
+from tensorboardX.proto.event_pb2 import Event
 
 
 def _u32(x):

--- a/catalyst/utils/tests/test_tensorboard.py
+++ b/catalyst/utils/tests/test_tensorboard.py
@@ -193,3 +193,8 @@ def test_summary_reader_filter_scalars():
         assert item.tag == event_raw['tag']
         assert item.type == 'scalar'
         assert np.all(item.value == event_raw['value'])
+
+
+def test_summary_reader_invalid_type():
+    with pytest.raises(ValueError):
+        SummaryReader('.', type_filter=['unknown-type'])

--- a/catalyst/utils/tests/test_tensorboard.py
+++ b/catalyst/utils/tests/test_tensorboard.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import cv2
 import numpy as np
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 from catalyst.utils.tensorboard import \
     EventsFileReader, EventReadingError, SummaryReader

--- a/catalyst/utils/tests/test_tensorboard.py
+++ b/catalyst/utils/tests/test_tensorboard.py
@@ -174,3 +174,22 @@ def test_summary_reader_filter():
         assert item.type == event_raw['type']
         assert item.tag in tags
         assert np.all(item.value == event_raw['value'])
+
+
+@patch('pathlib.Path.glob', lambda s, p: [Path('1'), Path('2')])
+@patch('pathlib.Path.is_file', lambda s: True)
+@patch('builtins.open', _open)
+def test_summary_reader_filter_scalars():
+    types = ['scalar']
+    reader = SummaryReader('logs', type_filter=types)
+    _, data_raw = _get_test_data()
+    data_raw2 = 2 * [d for d in data_raw if d is not None and d['type'] in types]
+    items = list(reader)
+
+    assert len(items) == len(data_raw2)
+
+    for item, event_raw in zip(items, data_raw2):
+        assert item.step == event_raw['step']
+        assert item.tag == event_raw['tag']
+        assert item.type == 'scalar'
+        assert np.all(item.value == event_raw['value'])

--- a/catalyst/utils/tests/test_tensorboard.py
+++ b/catalyst/utils/tests/test_tensorboard.py
@@ -6,7 +6,8 @@ import numpy as np
 import pytest
 from mock import patch
 
-from catalyst.utils.tensorboard import EventsFileReader, EventReadingError, SummaryReader
+from catalyst.utils.tensorboard import \
+    EventsFileReader, EventReadingError, SummaryReader
 
 
 def _get_test_data():

--- a/catalyst/utils/tests/test_tensorboard.py
+++ b/catalyst/utils/tests/test_tensorboard.py
@@ -183,7 +183,8 @@ def test_summary_reader_filter_scalars():
     types = ['scalar']
     reader = SummaryReader('logs', types=types)
     _, data_raw = _get_test_data()
-    data_raw2 = 2 * [d for d in data_raw if d is not None and d['type'] in types]
+    data_raw2 = 2 * [d for d in data_raw
+                     if d is not None and d['type'] in types]
     items = list(reader)
 
     assert len(items) == len(data_raw2)

--- a/catalyst/utils/tests/test_tensorboard.py
+++ b/catalyst/utils/tests/test_tensorboard.py
@@ -152,6 +152,7 @@ def test_summary_reader_iterate():
     for item, event_raw in zip(items, data_raw2):
         assert item.step == event_raw['step']
         assert item.tag == event_raw['tag']
+        assert item.type == event_raw['type']
         assert np.all(item.value == event_raw['value'])
 
 
@@ -170,5 +171,6 @@ def test_summary_reader_filter():
     for item, event_raw in zip(items, data_raw2):
         assert item.step == event_raw['step']
         assert item.tag == event_raw['tag']
+        assert item.type == event_raw['type']
         assert item.tag in tags
         assert np.all(item.value == event_raw['value'])

--- a/catalyst/utils/tests/test_tensorboard.py
+++ b/catalyst/utils/tests/test_tensorboard.py
@@ -1,0 +1,173 @@
+from io import BytesIO
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+from mock import patch
+
+from catalyst.utils.tensorboard import EventsFileReader, EventReadingError, SummaryReader
+
+
+def _get_test_data():
+    """Test events file
+
+    tag  value         step
+    -----------------------
+    x     1.0          1
+    y    -1.0          1
+    x     2.0          2
+    z     zeros 2×2×3  1
+
+    The first event is empty with wall_time = 1557489465
+
+    log.add_scalar('x', 1.0, global_step=1)
+    log.add_scalar('y', -1.0, global_step=1)
+    log.add_scalar('x', 2.0, global_step=2)
+    log.add_image('z', np.zeros((2, 2, 1)), global_step=1)
+    """
+
+    data_raw = [
+        None,
+        {
+            'tag': 'x',
+            'value': 1.0,
+            'step': 1,
+            'type': 'scalar'
+        },
+        {
+            'tag': 'y',
+            'value': -1.0,
+            'step': 1,
+            'type': 'scalar'
+        },
+        {
+            'tag': 'x',
+            'value': 2.0,
+            'step': 2,
+            'type': 'scalar'
+        },
+        {
+            'tag': 'z',
+            'value': np.zeros((2, 2, 3)),
+            'height': 2,
+            'width': 2,
+            'channels': 3,
+            'step': 1,
+            'type': 'image'
+        },
+    ]
+    data = b'\t\x00\x00\x00\x00\x00\x00\x007\xf9q9\t\xc9\xebE\x18`5' \
+           b'\xd7A\x04A\xf4n\x17\x00\x00\x00\x00\x00\x00\x00\xe7\xce' \
+           b'\xf8\x1e\t=\x82{\x19`5\xd7A\x10\x01*\n\n\x08\n\x01x\x15' \
+           b'\x00\x00\x80?c\xf1\xd84\x17\x00\x00\x00\x00\x00\x00\x00' \
+           b'\xe7\xce\xf8\x1e\tT\xe4g\x1a`5\xd7A\x10\x01*\n\n\x08\n' \
+           b'\x01y\x15\x00\x00\x80\xbf{;wp\x17\x00\x00\x00\x00\x00\x00' \
+           b'\x00\xe7\xce\xf8\x1e\t"S\xbc\x1b`5\xd7A\x10\x02*\n\n\x08' \
+           b'\n\x01x\x15\x00\x00\x00@\x1d\xb9\xdc\x83`\x00\x00\x00\x00' \
+           b'\x00\x00\x00(!\xc6\xda\t.\x03H"`5\xd7A\x10\x01*S\nQ\n\x01' \
+           b'z"L\x08\x02\x10\x02\x18\x03"D\x89PNG\r\n\x1a\n\x00\x00\x00' \
+           b'\rIHDR\x00\x00\x00\x02\x00\x00\x00\x02\x08\x02\x00\x00\x00' \
+           b'\xfd\xd4\x9as\x00\x00\x00\x0bIDATx\x9cc`@\x06\x00\x00\x0e' \
+           b'\x00\x01\xa9\x91s\xb1\x00\x00\x00\x00IEND\xaeB`\x82\x96x9j'
+    return data, data_raw
+
+
+def _compare_image_data(png, data):
+    png_buf = np.frombuffer(png, np.uint8)
+    png_decoded = cv2.imdecode(png_buf, cv2.IMREAD_COLOR)
+    assert np.all(png_decoded == data), 'Corrupted image data'
+
+
+def test_events_reader_successful():
+    data, data_raw = _get_test_data()
+    reader = EventsFileReader(BytesIO(data))
+    for event, event_raw in zip(reader, data_raw):
+        if event_raw is not None:
+            assert event.step == event_raw['step']
+            assert event.HasField('summary')
+            assert len(event.summary.value) == 1
+            if event_raw['type'] == 'scalar':
+                assert event.summary.value[0].HasField('simple_value')
+                assert event.summary.value[0].tag == event_raw['tag']
+                assert event.summary.value[0].simple_value == event_raw['value'
+                                                                        ]
+            elif event_raw['type'] == 'image':
+                assert event.summary.value[0].HasField('image')
+                assert event.summary.value[0].image.height == 2
+                assert event.summary.value[0].image.width == 2
+                assert event.summary.value[0].image.colorspace == 3
+                _compare_image_data(
+                    event.summary.value[0].image.encoded_image_string,
+                    event_raw['value']
+                )
+
+
+def test_events_reader_empty():
+    data = BytesIO(b'')
+    reader = EventsFileReader(data)
+    assert len(list(reader)) == 0
+
+
+def test_events_reader_invalid_data():
+    data, _ = _get_test_data()
+    data1 = bytearray(data)
+    data1[0] = (data1[0] + 1) % 256
+    reader = EventsFileReader(BytesIO(data1))
+    with pytest.raises(EventReadingError):
+        list(reader)
+
+    data2 = bytearray(data)
+    data2[123] = (data2[123] + 1) % 256
+    reader = EventsFileReader(BytesIO(data2))
+    with pytest.raises(EventReadingError):
+        list(reader)
+
+
+def test_events_reader_unexpected_end():
+    data, _ = _get_test_data()
+    data = data[:-5]
+    reader = EventsFileReader(BytesIO(data))
+    with pytest.raises(EventReadingError):
+        list(reader)
+
+
+def _open(path, mode):
+    data, _ = _get_test_data()
+    return BytesIO(data)
+
+
+@patch('pathlib.Path.glob', lambda s, p: [Path('1'), Path('2')])
+@patch('pathlib.Path.is_file', lambda s: True)
+@patch('builtins.open', _open)
+def test_summary_reader_iterate():
+    reader = SummaryReader('logs')
+    _, data_raw = _get_test_data()
+    data_raw2 = 2 * [d for d in data_raw if d is not None]
+    items = list(reader)
+
+    assert len(items) == len(data_raw2)
+
+    for item, event_raw in zip(items, data_raw2):
+        assert item.step == event_raw['step']
+        assert item.tag == event_raw['tag']
+        assert np.all(item.value == event_raw['value'])
+
+
+@patch('pathlib.Path.glob', lambda s, p: [Path('1'), Path('2')])
+@patch('pathlib.Path.is_file', lambda s: True)
+@patch('builtins.open', _open)
+def test_summary_reader_filter():
+    tags = ['x', 'z']
+    reader = SummaryReader('logs', tag_filter=tags)
+    _, data_raw = _get_test_data()
+    data_raw2 = 2 * [d for d in data_raw if d is not None and d['tag'] in tags]
+    items = list(reader)
+
+    assert len(items) == len(data_raw2)
+
+    for item, event_raw in zip(items, data_raw2):
+        assert item.step == event_raw['step']
+        assert item.tag == event_raw['tag']
+        assert item.tag in tags
+        assert np.all(item.value == event_raw['value'])

--- a/catalyst/utils/tests/test_tensorboard.py
+++ b/catalyst/utils/tests/test_tensorboard.py
@@ -142,7 +142,7 @@ def _open(path, mode):
 @patch('pathlib.Path.is_file', lambda s: True)
 @patch('builtins.open', _open)
 def test_summary_reader_iterate():
-    reader = SummaryReader('logs')
+    reader = SummaryReader('logs', types=['scalar', 'image'])
     _, data_raw = _get_test_data()
     data_raw2 = 2 * [d for d in data_raw if d is not None]
     items = list(reader)
@@ -161,7 +161,7 @@ def test_summary_reader_iterate():
 @patch('builtins.open', _open)
 def test_summary_reader_filter():
     tags = ['x', 'z']
-    reader = SummaryReader('logs', tag_filter=tags)
+    reader = SummaryReader('logs', tag_filter=tags, types=['scalar', 'image'])
     _, data_raw = _get_test_data()
     data_raw2 = 2 * [d for d in data_raw if d is not None and d['tag'] in tags]
     items = list(reader)
@@ -181,7 +181,7 @@ def test_summary_reader_filter():
 @patch('builtins.open', _open)
 def test_summary_reader_filter_scalars():
     types = ['scalar']
-    reader = SummaryReader('logs', type_filter=types)
+    reader = SummaryReader('logs', types=types)
     _, data_raw = _get_test_data()
     data_raw2 = 2 * [d for d in data_raw if d is not None and d['type'] in types]
     items = list(reader)
@@ -197,4 +197,4 @@ def test_summary_reader_filter_scalars():
 
 def test_summary_reader_invalid_type():
     with pytest.raises(ValueError):
-        SummaryReader('.', type_filter=['unknown-type'])
+        SummaryReader('.', types=['unknown-type'])

--- a/docker/Dockerfile-041
+++ b/docker/Dockerfile-041
@@ -31,7 +31,9 @@ RUN pip install --no-cache-dir \
     torchnet \
     redis \
     gym \
-    catalyst
+    catalyst \
+    tensorboardX \
+    crc32c
 
 CMD mkdir -p /workspace
 WORKDIR /workspace

--- a/docker/Dockerfile-100
+++ b/docker/Dockerfile-100
@@ -31,7 +31,9 @@ RUN pip install --no-cache-dir \
     torchnet \
     redis \
     gym \
-    catalyst
+    catalyst \
+    tensorboardX \
+    crc32c
 
 CMD mkdir -p /workspace
 WORKDIR /workspace

--- a/docker/Dockerfile-contrib-041
+++ b/docker/Dockerfile-contrib-041
@@ -36,7 +36,8 @@ RUN pip install --no-cache-dir \
     albumentations \
     seaborn \
     tensorboardX \
-    wrappa
+    wrappa \
+    crc32c
 
 CMD mkdir -p /workspace
 WORKDIR /workspace

--- a/docker/Dockerfile-contrib-041
+++ b/docker/Dockerfile-contrib-041
@@ -35,7 +35,8 @@ RUN pip install --no-cache-dir \
     nmslib \
     albumentations \
     seaborn \
-    tensorflow \
+    tensorboard \
+    tensorboardX \
     wrappa
 
 CMD mkdir -p /workspace

--- a/docker/Dockerfile-contrib-041
+++ b/docker/Dockerfile-contrib-041
@@ -35,7 +35,6 @@ RUN pip install --no-cache-dir \
     nmslib \
     albumentations \
     seaborn \
-    tensorboard \
     tensorboardX \
     wrappa
 

--- a/docker/Dockerfile-contrib-100
+++ b/docker/Dockerfile-contrib-100
@@ -36,7 +36,8 @@ RUN pip install --no-cache-dir \
     albumentations \
     seaborn \
     tensorboardX \
-    wrappa
+    wrappa \
+    crc32c
 
 CMD mkdir -p /workspace
 WORKDIR /workspace

--- a/docker/Dockerfile-contrib-100
+++ b/docker/Dockerfile-contrib-100
@@ -35,7 +35,8 @@ RUN pip install --no-cache-dir \
     nmslib \
     albumentations \
     seaborn \
-    tensorflow \
+    tensorboard \
+    tensorboardX \
     wrappa
 
 CMD mkdir -p /workspace

--- a/docker/Dockerfile-contrib-100
+++ b/docker/Dockerfile-contrib-100
@@ -35,7 +35,6 @@ RUN pip install --no-cache-dir \
     nmslib \
     albumentations \
     seaborn \
-    tensorboard \
     tensorboardX \
     wrappa
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ tqdm>=4.29.1
 PyYAML
 tensorboardX>=1.6
 plotly>=3.6.1
-tensorflow==1.13.1
 torchnet
 crc32c>=1.7
 tensorboard>=1.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,8 @@ tensorboardX>=1.6
 plotly>=3.6.1
 tensorflow==1.13.1
 torchnet
+crc32c>=1.7
+tensorboard>=1.13.1
 
 # Used in scripts
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ tensorboardX>=1.6
 plotly>=3.6.1
 torchnet
 crc32c>=1.7
-tensorboard>=1.13.1
 
 # Used in scripts
 matplotlib


### PR DESCRIPTION
Parse Tensorboard logs without importing tensorflow (#130).


Changes:

- [x] Add a parser for TB logs.
- [x] Rewrite  [`catalyst.utils.plotly`](https://github.com/catalyst-team/catalyst/blob/master/catalyst/utils/plotly.py).
- [x] Check it on real data.
- [x] Remove `tensorflow` from [`catalyst.contrib.scripts.project_embeddings`](https://github.com/catalyst-team/catalyst/blob/master/catalyst/contrib/scripts/project_embeddings.py)
- [x] ~Remove `tensorflow` from [`catalyst.utils.misc`](https://github.com/catalyst-team/catalyst/blob/master/catalyst/utils/misc.py)~
- [x] Remove `tensorflow` from `requirements.txt`.