### PR TITLE
Add Seaborn library to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ torchnet
 
 # Used in scripts
 matplotlib
+seaborn
 pandas>=0.22
 scikit-learn>=0.20
 


### PR DESCRIPTION
Seaborn is currently used in `catalyst/dl/scripts/make_report.py`, but
is not present in `requirements.txt`.