### PR TITLE
Segmented on policy

### DIFF
--- a/catalyst/rl/onpolicy/algorithms/reinforce.py
+++ b/catalyst/rl/onpolicy/algorithms/reinforce.py
@@ -25,12 +25,12 @@ class REINFORCE(ActorAlgorithmSpec):
 
     @torch.no_grad()
     def get_rollout(self, states, actions, rewards, dones):
-        states = self._to_tensor(states)
-        actions = self._to_tensor(actions)
+        states2gpu = self._to_tensor(states)
+        actions2gpu = self._to_tensor(actions)
         rewards = np.array(rewards)
         trajectory_len = rewards.shape[0]
 
-        _, logprobs = self.actor(states, logprob=actions)
+        _, logprobs = self.actor(states2gpu, logprob=actions2gpu)
         logprobs = logprobs.cpu().numpy().reshape(-1)
 
         returns = np.dot(
@@ -38,6 +38,9 @@ class REINFORCE(ActorAlgorithmSpec):
             rewards)
 
         rollout = {
+            "state": states,
+            "action": actions,
+            "reward": rewards,
             "return": returns,
             "action_logprob": logprobs
         }

--- a/catalyst/rl/onpolicy/algorithms/reinforce.py
+++ b/catalyst/rl/onpolicy/algorithms/reinforce.py
@@ -24,7 +24,7 @@ class REINFORCE(ActorAlgorithmSpec):
         }
 
     @torch.no_grad()
-    def get_rollout(self, states, actions, rewards):
+    def get_rollout(self, states, actions, rewards, dones):
         states = self._to_tensor(states)
         actions = self._to_tensor(actions)
         rewards = np.array(rewards)

--- a/catalyst/rl/onpolicy/sampler.py
+++ b/catalyst/rl/onpolicy/sampler.py
@@ -60,7 +60,7 @@ class Sampler:
             agent=self.agent,
             device=self._device,
             capacity=buffer_size,
-            deterministic=self._infer
+            deterministic=self._infer,
             segment_length=segment_length
         )
 

--- a/catalyst/rl/onpolicy/sampler.py
+++ b/catalyst/rl/onpolicy/sampler.py
@@ -183,14 +183,14 @@ class Sampler:
             if not self._infer or self._force_store:
                 self._store_trajectory()
 
-            self._log_to_console(
-                **episode_info,
-                elapsed_time=elapsed_time,
-                seed=seed)
-
-            self._log_to_tensorboard(
-                **episode_info,
-                elapsed_time=elapsed_time)
+            if episode_info:
+                self._log_to_console(
+                    **episode_info,
+                    elapsed_time=elapsed_time,
+                    seed=seed)
+                self._log_to_tensorboard(
+                    **episode_info,
+                    elapsed_time=elapsed_time)
 
             self.episode_index += 1
             if self.episode_index % self._gc_period == 0:

--- a/catalyst/rl/onpolicy/sampler.py
+++ b/catalyst/rl/onpolicy/sampler.py
@@ -38,6 +38,7 @@ class Sampler:
         episode_limit: int = None,
         force_store: bool = False,
         gc_period: int = 10,
+        segment_length: int = None
     ):
         self._device = UtilsFactory.prepare_device()
         self._seed = 42 + id
@@ -60,6 +61,7 @@ class Sampler:
             device=self._device,
             capacity=buffer_size,
             deterministic=self._infer
+            segment_length=segment_length
         )
 
         # synchronization configuration

--- a/catalyst/rl/onpolicy/trainer.py
+++ b/catalyst/rl/onpolicy/trainer.py
@@ -132,10 +132,12 @@ class Trainer:
             self._num_trajectories += 1
             self._num_transitions += len(episode[-1])
 
-            observations, actions, rewards, _ = episode
+            observations, actions, rewards, dones = episode
             states = _get_states_from_observations(
                 observations, self.env_spec.history_len)
-            rollout = self.algorithm.get_rollout(states, actions, rewards)
+            rollout = self.algorithm.get_rollout(
+                states, actions, rewards, dones
+            )
             self.replay_buffer.push_rollout(
                 state=states,
                 action=actions,

--- a/catalyst/rl/onpolicy/trainer.py
+++ b/catalyst/rl/onpolicy/trainer.py
@@ -138,12 +138,7 @@ class Trainer:
             rollout = self.algorithm.get_rollout(
                 states, actions, rewards, dones
             )
-            self.replay_buffer.push_rollout(
-                state=states,
-                action=actions,
-                reward=rewards,
-                **rollout,
-            )
+            self.replay_buffer.push_rollout(**rollout)
 
         # @TODO: refactor
         self.algorithm.postprocess_buffer(

--- a/catalyst/rl/utils.py
+++ b/catalyst/rl/utils.py
@@ -421,6 +421,8 @@ class EpisodeRunner:
         self.deterministic = deterministic
         self.segment_length = segment_length or _BIG_NUM
         self.init_observation = None
+        self.episode_reward = 0
+        self.episode_num_steps = 0
         self.policy_handler = PolicyHandler(
             env=self.env, agent=self.agent, device=device
         )
@@ -527,11 +529,18 @@ class EpisodeRunner:
             if num_steps % self.segment_length == 0:
                 break
 
+        self.episode_reward += episode_reward
+        self.episode_num_steps += num_steps
         if done:
             self.init_observation = None
+            results = {
+                "episode_reward": self.episode_reward,
+                "num_steps": self.episode_num_steps
+            }
+            self.episode_reward = 0
+            self.episode_num_steps = 0
         else:
             self.init_observation = next_observation
-
-        results = {"episode_reward": episode_reward, "num_steps": num_steps}
+            results = {}
 
         return results

--- a/catalyst/rl/utils.py
+++ b/catalyst/rl/utils.py
@@ -500,7 +500,10 @@ class EpisodeRunner:
             exploration_strategy.update_actor(self.agent, states)
 
         self._init_buffers()
-        self._init_with_observation(self.init_observation or self.env.reset())
+        if self.init_observation is not None:
+            self._init_with_observation(self.init_observation)
+        else:
+            self._init_with_observation(self.env.reset())
 
     def run(self, exploration_strategy):
         episode_reward, num_steps, done = 0, 0, False
@@ -521,8 +524,7 @@ class EpisodeRunner:
             transition = [next_observation, action, reward, done]
             self._put_transition(transition)
             num_steps += 1
-
-            if num_steps % self.segment_length:
+            if num_steps % self.segment_length == 0:
                 break
 
         if done:


### PR DESCRIPTION
Added functionality to collect segments of trajectories in on-policy methods instead of collecting complete episodes. To control the segment length, a parameter **segment_length** has been added to sampler. The default value is **None** which corresponds to segments of length **episode_len**.

Tested on LunarLander-v2 with **segment_length=128**.