### PR TITLE
Max length removal

### DIFF
--- a/catalyst/rl/onpolicy/algorithms/ppo.py
+++ b/catalyst/rl/onpolicy/algorithms/ppo.py
@@ -28,8 +28,9 @@ class PPO(ActorCriticAlgorithmSpec):
 
     @torch.no_grad()
     def get_rollout(self, states, actions, rewards, dones):
-        
-        trajectory_len = rewards.shape[0] if dones[-1] else rewards.shape[0]-1
+        trajectory_len = \
+            rewards.shape[0] if dones[-1] else rewards.shape[0] - 1
+
         states = self._to_tensor(states)
         actions = self._to_tensor(actions)
         rewards = np.array(rewards)[:trajectory_len]
@@ -44,8 +45,6 @@ class PPO(ActorCriticAlgorithmSpec):
         deltas = rewards + self.gamma * values[1:] - values[:-1]
         advantages = geometric_cumsum(self.gamma, deltas)[0]
         returns = geometric_cumsum(self.gamma * self.gae_lambda, rewards)[0]
-        
-        #print (returns.shape, values.shape, advantages.shape, logprobs.shape)
 
         rollout = {
             "return": returns,

--- a/catalyst/rl/onpolicy/algorithms/reinforce.py
+++ b/catalyst/rl/onpolicy/algorithms/reinforce.py
@@ -20,14 +20,16 @@ class REINFORCE(ActorAlgorithmSpec):
         }
 
     @torch.no_grad()
-    def get_rollout(self, states, actions, rewards):
+    def get_rollout(self, states, actions, rewards, dones):
+        trajectory_len = \
+            rewards.shape[0] if dones[-1] else rewards.shape[0] - 1
+
         states = self._to_tensor(states)
         actions = self._to_tensor(actions)
-        rewards = np.array(rewards)
-        trajectory_len = rewards.shape[0]
+        rewards = np.array(rewards)[:trajectory_len]
 
         _, logprobs = self.actor(states, logprob=actions)
-        logprobs = logprobs.cpu().numpy().reshape(-1)
+        logprobs = logprobs.cpu().numpy().reshape(-1)[:trajectory_len]
 
         returns = geometric_cumsum(self.gamma, rewards)[0]
 

--- a/catalyst/rl/onpolicy/algorithms/utils.py
+++ b/catalyst/rl/onpolicy/algorithms/utils.py
@@ -3,11 +3,20 @@ from scipy.signal import lfilter
 
 
 def geometric_cumsum(alpha, x):
-    r"""
-    Adapopted from https://github.com/zuoxingdong/lagom
+    """
+    Adapted from https://github.com/zuoxingdong/lagom
     """
     x = np.asarray(x)
     if x.ndim == 1:
         x = np.expand_dims(x, 0)
     assert x.ndim == 2
     return lfilter([1], [1, -alpha], x[:, ::-1], axis=1)[:, ::-1]
+
+
+def append_dict(dict1, dict2):
+    """
+    Appends dict2 with the same keys as dict1 to dict1
+    """
+    for key in dict1.keys():
+        dict1[key] = np.concatenate((dict1[key], dict2[key]))
+    return dict1

--- a/catalyst/rl/onpolicy/algorithms/utils.py
+++ b/catalyst/rl/onpolicy/algorithms/utils.py
@@ -1,19 +1,13 @@
 import numpy as np
+from scipy.signal import lfilter
 
 
-def create_gamma_matrix(tau, matrix_size):
+def geometric_cumsum(alpha, x):
+    r"""
+    Adapopted from https://github.com/zuoxingdong/lagom
     """
-    Matrix of the following form
-    --------------------
-    1     y   y^2    y^3
-    0     1     y    y^2
-    0     0     1      y
-    0     0     0      1
-    --------------------
-    for fast gae calculation
-    """
-    i = np.arange(matrix_size)
-    j = np.arange(matrix_size)
-    pow_ = i[None, :] - j[:, None]
-    mat = np.power(tau, pow_) * (pow_ >= 0)
-    return mat
+    x = np.asarray(x)
+    if x.ndim == 1:
+        x = np.expand_dims(x, 0)
+    assert x.ndim == 2
+    return lfilter([1], [1, -alpha], x[:, ::-1], axis=1)[:, ::-1]

--- a/catalyst/rl/onpolicy/trainer.py
+++ b/catalyst/rl/onpolicy/trainer.py
@@ -139,7 +139,9 @@ class Trainer:
             observations, actions, rewards, dones = episode
             states = _get_states_from_observations(
                 observations, self.env_spec.history_len)
-            rollout = self._get_rollout_in_batches(states, actions, rewards, dones)
+            rollout = self._get_rollout_in_batches(
+                states, actions, rewards, dones
+            )
             self.replay_buffer.push_rollout(
                 state=states,
                 action=actions,
@@ -155,14 +157,14 @@ class Trainer:
         elapsed_time = time.time() - start_time
         self.logger.add_scalar("fetch time", elapsed_time, self.epoch)
 
-
     def _get_rollout_in_batches(self, states, actions, rewards, dones):
 
         if self.rollout_batch_size is None:
             return self.algorithm.get_rollout(states, actions, rewards, dones)
 
         indices = np.arange(
-            0, len(states) + self.rollout_batch_size - 1, self.rollout_batch_size
+            0, len(states) + self.rollout_batch_size - 1,
+            self.rollout_batch_size
         )
         rollout = None
         for i in range(len(indices) - 1):
@@ -178,7 +180,6 @@ class Trainer:
             else:
                 rollout = rollout_batch
         return rollout
-
 
     def _update_samplers_weights(self):
         mode = self._sampler_weight_mode


### PR DESCRIPTION
1. Removed **max_episode_len** parameter in on-policy algorithms.
2. Matrix multiplication by gamma matrix when calculating cumulative geometric sums replaced by faster and more memory efficient operation.
3. Added parameter **rollout_batch_size** to on-policy methods which allows to calculate rollout statistics by small batches of states (to fix memory overhead issue). Tested on PPO for LunarLander-v2.