### PR TITLE
Bug fix: Fp16 is enabled for `fp16=False`

### DIFF
--- a/catalyst/dl/experiments/runner.py
+++ b/catalyst/dl/experiments/runner.py
@@ -78,7 +78,7 @@ class SupervisedRunner(Runner):
         fp16: Union[Dict, bool] = None,
         check: bool = False,
     ):
-        if isinstance(fp16, bool):
+        if isinstance(fp16, bool) and fp16:
             fp16 = {"opt_level": "O1"}
         experiment = self._default_experiment(
             stage="train",
@@ -110,7 +110,7 @@ class SupervisedRunner(Runner):
         fp16: Union[Dict, bool] = None,
         check: bool = False,
     ):
-        if isinstance(fp16, bool):
+        if isinstance(fp16, bool) and fp16:
             fp16 = {"opt_level": "O1"}
         experiment = self._default_experiment(
             stage="infer",


### PR DESCRIPTION
A condition checked whether `fp16` has boolean type, and not the value. This caused bug (fp16 were turned on) if user sets `fp16=False`.