### PR TITLE
Bugs/fix batch size loader

### DIFF
--- a/catalyst/dl/callbacks/base.py
+++ b/catalyst/dl/callbacks/base.py
@@ -137,11 +137,11 @@ class CheckpointCallback(Callback):
 
 class IterationCheckpointCallback(Callback):
     """
-    Iteration checkpoint callback to save your model/criterion/optimizer/metrics
+    Iteration checkpoint callback to save your model/criterion/optimizer
     """
 
     def __init__(
-        self, num_iters : int = 100, stage_restart : bool = True
+        self, num_iters: int = 100, stage_restart: bool = True
     ):
         """
         :param num_iters: save the checkpoint every `n_iters`
@@ -156,7 +156,10 @@ class IterationCheckpointCallback(Callback):
         logdir,
         checkpoint
     ):
-        suffix = f"{checkpoint['stage']}.epoch.{checkpoint['epoch']}.iter.{self._iteration_counter}"
+        suffix = f"{checkpoint['stage']}." \
+                 f"epoch.{checkpoint['epoch']}." \
+                 f"iter.{self._iteration_counter}"
+
         filepath = UtilsFactory.save_checkpoint(
             logdir=f"{logdir}/checkpoints/",
             checkpoint=checkpoint,

--- a/catalyst/dl/callbacks/base.py
+++ b/catalyst/dl/callbacks/base.py
@@ -135,6 +135,65 @@ class CheckpointCallback(Callback):
         print(top_best_metrics_str)
 
 
+class IterationCheckpointCallback(Callback):
+    """
+    Iteration checkpoint callback to save your model/criterion/optimizer/metrics
+    """
+
+    def __init__(
+        self, n_iters : int = 100, stage_restart : bool = True
+    ):
+        """
+        :param n_iters: save the checkpoint every `n_iters`
+        :param stage_restart: restart counter every stage or not
+        """
+        self.n_iters = n_iters
+        self.stage_restart = stage_restart
+        self._iteration_counter = 0
+
+    def save_checkpoint(
+        self,
+        logdir,
+        checkpoint,
+        is_best,
+    ):
+        suffix = f"{checkpoint['stage']}.epoch.{checkpoint['epoch']}.iter.{self._iteration_counter}"
+        filepath = UtilsFactory.save_checkpoint(
+            logdir=f"{logdir}/checkpoints/",
+            checkpoint=checkpoint,
+            suffix=suffix,
+            is_best=is_best,
+            is_last=True
+        )
+        print(f"\nSaved checkpoint at {filepath}")
+
+    def pack_checkpoint(self, **kwargs):
+        return UtilsFactory.pack_checkpoint(**kwargs)
+
+    def on_batch_end(self, state):
+        self._iteration_counter += 1
+        if self._iteration_counter % self.n_iters == 0:
+            checkpoint = self.pack_checkpoint(
+                model=state.model,
+                criterion=state.criterion,
+                optimizer=state.optimizer,
+                scheduler=state.scheduler,
+                epoch_metrics=None,
+                valid_metrics=None,
+                stage=state.stage,
+                epoch=state.epoch
+            )
+            self.save_checkpoint(
+                logdir=state.logdir,
+                checkpoint=checkpoint,
+                is_best=False
+            )
+
+    def on_stage_start(self, state):
+        if self.stage_restart:
+            self._iteration_counter = 0
+
+
 class OptimizerCallback(Callback):
     """
     Optimizer callback, abstraction over optimizer step.

--- a/catalyst/dl/callbacks/base.py
+++ b/catalyst/dl/callbacks/base.py
@@ -141,7 +141,10 @@ class IterationCheckpointCallback(Callback):
     """
 
     def __init__(
-        self, save_n_last: int = 3, num_iters: int = 100, stage_restart: bool = True
+        self,
+        save_n_last: int = 3,
+        num_iters: int = 100,
+        stage_restart: bool = True
     ):
 
         """

--- a/catalyst/dl/callbacks/base.py
+++ b/catalyst/dl/callbacks/base.py
@@ -226,7 +226,7 @@ class OptimizerCallback(Callback):
         else:
             loss.backward()
 
-        if (self._accumulation_counter + 1) % self.accumulation_steps == 0:
+        if self._accumulation_counter % self.accumulation_steps == 0:
             self.grad_step(
                 optimizer=optimizer,
                 optimizer_wd=self._optimizer_wd,

--- a/catalyst/dl/callbacks/base.py
+++ b/catalyst/dl/callbacks/base.py
@@ -141,34 +141,37 @@ class IterationCheckpointCallback(Callback):
     """
 
     def __init__(
-        self, n_iters : int = 100, stage_restart : bool = True
+        self, num_iters : int = 100, stage_restart : bool = True
     ):
         """
-        :param n_iters: save the checkpoint every `n_iters`
+        :param num_iters: save the checkpoint every `n_iters`
         :param stage_restart: restart counter every stage or not
         """
-        self.n_iters = n_iters
+        self.n_iters = num_iters
         self.stage_restart = stage_restart
         self._iteration_counter = 0
 
     def save_checkpoint(
         self,
         logdir,
-        checkpoint,
-        is_best,
+        checkpoint
     ):
         suffix = f"{checkpoint['stage']}.epoch.{checkpoint['epoch']}.iter.{self._iteration_counter}"
         filepath = UtilsFactory.save_checkpoint(
             logdir=f"{logdir}/checkpoints/",
             checkpoint=checkpoint,
             suffix=suffix,
-            is_best=is_best,
-            is_last=True
+            is_best=False,
+            is_last=False
         )
         print(f"\nSaved checkpoint at {filepath}")
 
     def pack_checkpoint(self, **kwargs):
         return UtilsFactory.pack_checkpoint(**kwargs)
+
+    def on_stage_start(self, state):
+        if self.stage_restart:
+            self._iteration_counter = 0
 
     def on_batch_end(self, state):
         self._iteration_counter += 1
@@ -185,13 +188,8 @@ class IterationCheckpointCallback(Callback):
             )
             self.save_checkpoint(
                 logdir=state.logdir,
-                checkpoint=checkpoint,
-                is_best=False
+                checkpoint=checkpoint
             )
-
-    def on_stage_start(self, state):
-        if self.stage_restart:
-            self._iteration_counter = 0
 
 
 class OptimizerCallback(Callback):

--- a/catalyst/dl/experiments/core.py
+++ b/catalyst/dl/experiments/core.py
@@ -191,7 +191,10 @@ class Runner(ABC):
         self.state.output = self.predict_batch(batch)
 
     def _run_loader(self, loader):
-        self.state.batch_size = loader.batch_size
+        if loader.batch_sampler:
+            self.state.batch_size = loader.batch_sampler.batch_size
+        else:
+            self.state.batch_size = loader.batch_size
         self.state.step = (
             self.state.step
             or self.state.epoch * len(loader) * self.state.batch_size

--- a/docs/api/dl.rst
+++ b/docs/api/dl.rst
@@ -72,6 +72,10 @@ Base
     :members:
     :undoc-members:
 
+.. autoclass:: IterationCheckpointCallback
+    :members:
+    :undoc-members:
+
 .. autoclass:: EarlyStoppingCallback
     :members:
     :undoc-members:


### PR DESCRIPTION
When dataloader use `batch_sampler`, there is no `batch_size` property inside the loader. It will cause the error. We need to take `batch_size` from `batch_sampler` instead of `loader`