### PR TITLE
MixupCallback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,12 @@ jobs:
         - PYTHONPATH=./examples:./catalyst:${PYTHONPATH}
           python catalyst/dl/scripts/run.py
           --expdir=./examples/_tests_mnist_stages2
+          --config=./examples/_tests_mnist_stages2/config3.yml
+          --logdir=./examples/logs/_tests_mnist_stages2
+          --check
+        - PYTHONPATH=./examples:./catalyst:${PYTHONPATH}
+          python catalyst/dl/scripts/run.py
+          --expdir=./examples/_tests_mnist_stages2
           --config=./examples/_tests_mnist_stages2/config2.yml
           --logdir=./examples/logs/_tests_mnist_stages2
           --check

--- a/catalyst/dl/callbacks/__init__.py
+++ b/catalyst/dl/callbacks/__init__.py
@@ -10,3 +10,4 @@ from .logging import VerboseLogger, ConsoleLogger, TensorboardLogger
 from .misc import EarlyStoppingCallback, ConfusionMatrixCallback
 from .optimizer import OptimizerCallback
 from .scheduler import SchedulerCallback, LRUpdater, LRFinder
+from .mixup import MixupCallback

--- a/catalyst/dl/callbacks/mixup.py
+++ b/catalyst/dl/callbacks/mixup.py
@@ -1,0 +1,45 @@
+from typing import List
+from catalyst.dl.core.state import RunnerState
+from catalyst.dl.callbacks import CriterionCallback
+import numpy as np
+import torch
+
+
+class MixupCallback(CriterionCallback):
+    def __init__(self, fields: List[str] = ('features',), alpha=1.0, train_only=True, **kwargs):
+        assert alpha >= 0, 'alpha must be>=0'
+
+        super(MixupCallback, self).__init__(**kwargs)
+
+        self.train_only = train_only
+        self.fields = fields
+        self.alpha = alpha
+        self.lam = 1
+        self.index = None
+
+    def on_batch_start(self, state: RunnerState):
+        if self.train_only and state.loader_name != 'train':
+            return
+        if self.alpha > 0:
+            self.lam = np.random.beta(self.alpha, self.alpha)
+        else:
+            self.lam = 1
+
+        self.index = torch.randperm(state.input[self.fields[0]].shape[0])
+        if state.input[self.fields[0]].is_cuda:
+            self.index = self.index.cuda()
+
+        for f in self.fields:
+            state.input[f] = self.lam * state.input[f] + (1 - self.lam) * state.input[f][self.index]
+
+    def _compute_loss(self, state: RunnerState, criterion):
+        if self.train_only and state.loader_name != 'train':
+            return super(MixupCallback, self)._compute_loss(state, criterion)
+        pred = state.output[self.output_key]
+        y_a = state.input[self.input_key]
+        y_b = state.input[self.input_key][self.index]
+
+        return self.lam * criterion(pred, y_a) + (1 - self.lam) * criterion(pred, y_b)
+
+
+__all__ = ['MixupCallback']

--- a/catalyst/dl/callbacks/mixup.py
+++ b/catalyst/dl/callbacks/mixup.py
@@ -20,8 +20,14 @@ class MixupCallback(CriterionCallback):
 
         You may not use them together.
     """
-    def __init__(self, fields: List[str] = ("features",), alpha=1.0,
-                 train_only=True, **kwargs):
+
+    def __init__(
+            self,
+            fields: List[str] = ("features",),
+            alpha=1.0,
+            train_only=True,
+            **kwargs
+    ):
         """
         Args:
             fields (List[str]): list of features which must be affected.

--- a/catalyst/dl/callbacks/mixup.py
+++ b/catalyst/dl/callbacks/mixup.py
@@ -6,7 +6,10 @@ import torch
 
 
 class MixupCallback(CriterionCallback):
-    def __init__(self, fields: List[str] = ('features',), alpha=1.0, train_only=True, **kwargs):
+    def __init__(self, fields: List[str] = ('features',), alpha=1.0,
+                 train_only=True, **kwargs):
+        assert len(
+            fields) > 0, 'At least one field for MixupCallback is required'
         assert alpha >= 0, 'alpha must be>=0'
 
         super(MixupCallback, self).__init__(**kwargs)
@@ -30,7 +33,8 @@ class MixupCallback(CriterionCallback):
             self.index = self.index.cuda()
 
         for f in self.fields:
-            state.input[f] = self.lam * state.input[f] + (1 - self.lam) * state.input[f][self.index]
+            state.input[f] = self.lam * state.input[f] + (1 - self.lam) * \
+                             state.input[f][self.index]
 
     def _compute_loss(self, state: RunnerState, criterion):
         if self.train_only and state.loader_name != 'train':
@@ -39,7 +43,8 @@ class MixupCallback(CriterionCallback):
         y_a = state.input[self.input_key]
         y_b = state.input[self.input_key][self.index]
 
-        return self.lam * criterion(pred, y_a) + (1 - self.lam) * criterion(pred, y_b)
+        return self.lam * criterion(pred, y_a) + (1 - self.lam) * criterion(
+            pred, y_b)
 
 
 __all__ = ['MixupCallback']

--- a/catalyst/dl/callbacks/mixup.py
+++ b/catalyst/dl/callbacks/mixup.py
@@ -9,8 +9,31 @@ from catalyst.dl.callbacks import CriterionCallback
 
 
 class MixupCallback(CriterionCallback):
+    """
+    Callback to do mixup augmentation.
+
+    Paper: https://arxiv.org/abs/1710.09412
+
+    Note:
+        MixupCallback is inherited from CriterionCallback and
+        does its work.
+
+        You may not use them together.
+    """
     def __init__(self, fields: List[str] = ("features",), alpha=1.0,
                  train_only=True, **kwargs):
+        """
+        Args:
+            fields (List[str]): list of features which must be affected.
+            alpha (float): beta distribution a=b parameters.
+                Must be >=0. The more alpha closer to zero
+                the less effect of the mixup
+            train_only (bool): Apply to train only.
+                As the mixup use the proxy inputs, the targets are also proxy.
+                We are not interested in them, are we?
+                So, if train_only is True, use a standard output/metric
+                for validation.
+        """
         assert len(fields) > 0, \
             "At least one field for MixupCallback is required"
         assert alpha >= 0, "alpha must be>=0"
@@ -22,12 +45,14 @@ class MixupCallback(CriterionCallback):
         self.alpha = alpha
         self.lam = 1
         self.index = None
+        self.is_needed = True
 
-    def _is_needed(self, state: RunnerState):
-        return not self.train_only or state.loader_name.startswith("train")
+    def on_loader_start(self, state: RunnerState):
+        self.is_needed = not self.train_only or \
+            state.loader_name.startswith("train")
 
     def on_batch_start(self, state: RunnerState):
-        if not self._is_needed(state):
+        if not self.is_needed:
             return
         if self.alpha > 0:
             self.lam = np.random.beta(self.alpha, self.alpha)
@@ -42,7 +67,7 @@ class MixupCallback(CriterionCallback):
                 (1 - self.lam) * state.input[f][self.index]
 
     def _compute_loss(self, state: RunnerState, criterion):
-        if not self._is_needed(state):
+        if not self.is_needed:
             return super()._compute_loss(state, criterion)
         pred = state.output[self.output_key]
         y_a = state.input[self.input_key]

--- a/catalyst/dl/callbacks/mixup.py
+++ b/catalyst/dl/callbacks/mixup.py
@@ -1,18 +1,21 @@
 from typing import List
+
+import numpy as np
+
+import torch
+
 from catalyst.dl.core.state import RunnerState
 from catalyst.dl.callbacks import CriterionCallback
-import numpy as np
-import torch
 
 
 class MixupCallback(CriterionCallback):
-    def __init__(self, fields: List[str] = ('features',), alpha=1.0,
+    def __init__(self, fields: List[str] = ("features",), alpha=1.0,
                  train_only=True, **kwargs):
-        assert len(
-            fields) > 0, 'At least one field for MixupCallback is required'
-        assert alpha >= 0, 'alpha must be>=0'
+        assert len(fields) > 0, \
+            "At least one field for MixupCallback is required"
+        assert alpha >= 0, "alpha must be>=0"
 
-        super(MixupCallback, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.train_only = train_only
         self.fields = fields
@@ -20,8 +23,11 @@ class MixupCallback(CriterionCallback):
         self.lam = 1
         self.index = None
 
+    def _is_needed(self, state: RunnerState):
+        return not self.train_only or state.loader_name.startswith("train")
+
     def on_batch_start(self, state: RunnerState):
-        if self.train_only and state.loader_name != 'train':
+        if not self._is_needed(state):
             return
         if self.alpha > 0:
             self.lam = np.random.beta(self.alpha, self.alpha)
@@ -29,22 +35,22 @@ class MixupCallback(CriterionCallback):
             self.lam = 1
 
         self.index = torch.randperm(state.input[self.fields[0]].shape[0])
-        if state.input[self.fields[0]].is_cuda:
-            self.index = self.index.cuda()
+        self.index.to(state.device)
 
         for f in self.fields:
-            state.input[f] = self.lam * state.input[f] + (1 - self.lam) * \
-                             state.input[f][self.index]
+            state.input[f] = self.lam * state.input[f] + \
+                (1 - self.lam) * state.input[f][self.index]
 
     def _compute_loss(self, state: RunnerState, criterion):
-        if self.train_only and state.loader_name != 'train':
-            return super(MixupCallback, self)._compute_loss(state, criterion)
+        if not self._is_needed(state):
+            return super()._compute_loss(state, criterion)
         pred = state.output[self.output_key]
         y_a = state.input[self.input_key]
         y_b = state.input[self.input_key][self.index]
 
-        return self.lam * criterion(pred, y_a) + (1 - self.lam) * criterion(
-            pred, y_b)
+        loss = self.lam * criterion(pred, y_a) + \
+            (1 - self.lam) * criterion(pred, y_b)
+        return loss
 
 
-__all__ = ['MixupCallback']
+__all__ = ["MixupCallback"]

--- a/catalyst/dl/callbacks/mixup.py
+++ b/catalyst/dl/callbacks/mixup.py
@@ -33,7 +33,7 @@ class MixupCallback(CriterionCallback):
             fields (List[str]): list of features which must be affected.
             alpha (float): beta distribution a=b parameters.
                 Must be >=0. The more alpha closer to zero
-                the less effect of the mixup
+                the less effect of the mixup.
             train_only (bool): Apply to train only.
                 As the mixup use the proxy inputs, the targets are also proxy.
                 We are not interested in them, are we?

--- a/docs/api/dl.rst
+++ b/docs/api/dl.rst
@@ -63,6 +63,11 @@ Callbacks
     :undoc-members:
     :show-inheritance:
 
+.. automodule:: catalyst.dl.callbacks.mixup
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 .. automodule:: catalyst.dl.callbacks.optimizer
     :members:
     :undoc-members:

--- a/examples/_tests_mnist_stages2/config3.yml
+++ b/examples/_tests_mnist_stages2/config3.yml
@@ -1,0 +1,49 @@
+model_params:
+  model: SimpleNet
+
+args:
+  expdir: "mnist_simple"
+  logdir: "./logs/mnist_simple"
+
+stages:
+
+  data_params:
+    batch_size: 64
+    num_workers: 0
+
+  state_params:
+    main_metric: &reduce_metric accuracy01
+    minimize_metric: False
+
+  criterion_params:
+      criterion: CrossEntropyLoss
+
+  optimizer_params:
+      optimizer: Adam
+      lr: 0.001
+      weight_decay: 0.0001
+
+  stage1:
+    state_params:
+      num_epochs: &num_epochs 4
+
+    scheduler_params:
+      scheduler: OneCycleLR
+      num_steps: *num_epochs
+      lr_range: [0.005, 0.00005]
+      warmup_steps: 1
+      momentum_range: [0.85, 0.95]
+
+    callbacks_params:
+      loss:
+        callback: MixupCallback
+      optimizer:
+        callback: OptimizerCallback
+      accuracy:
+        callback: AccuracyCallback
+        accuracy_args: [1, 3, 5]
+      scheduler:
+        callback: SchedulerCallback
+        reduce_metric: *reduce_metric
+      saver:
+        callback: CheckpointCallback


### PR DESCRIPTION
The callback for the mixup.

fields: features which must be affected by the mixup.

flpha: Beta distribution a=b parameters

train_only: boolean. Apply to train only? As the mixup use the proxy inputs, the targets are also proxy.
We are not interested in it, are we? So, if train_only is False, use a standard output/metric.