### PR TITLE
Invalid argument fix catalyst/utils/scripts.py:27

### DIFF
--- a/catalyst/utils/scripts.py
+++ b/catalyst/utils/scripts.py
@@ -30,16 +30,16 @@ def _tricky_dir_copy(dir_from, dir_to):
 
 def dump_code(expdir, logdir):
     expdir = expdir[:-1] if expdir.endswith("/") else expdir
-    new_src_dir = f"/code/"
+    new_src_dir = f"code"
 
     # @TODO: hardcoded
     old_pro_dir = os.path.dirname(os.path.abspath(__file__)) + "/../"
-    new_pro_dir = logdir + f"/{new_src_dir}/catalyst/"
+    new_pro_dir = os.path.join(logdir, new_src_dir, 'catalyst')
     _tricky_dir_copy(old_pro_dir, new_pro_dir)
 
     old_expdir = os.path.abspath(expdir)
-    expdir_ = expdir.rsplit("/", 1)[-1]
-    new_expdir = logdir + f"/{new_src_dir}/{expdir_}/"
+    expdir_ = os.path.basename(os.path.dirname(expdir))
+    new_expdir = os.path.join(logdir, new_src_dir, expdir_)
     _tricky_dir_copy(old_expdir, new_expdir)
 
 


### PR DESCRIPTION
Problem description:
In config.yml:

args:
  expdir: "."  (The working directory is the same)

```
Traceback (most recent call last):
  File "/home/light/miniconda3/bin/catalyst-dl", line 11, in <module>
    load_entry_point('catalyst==19.6.3', 'console_scripts', 'catalyst-dl')()
  File "/home/light/miniconda3/lib/python3.6/site-packages/catalyst-19.6.3-py3.6.egg/catalyst/dl/__main__.py", line 43, in main
    COMMANDS[args.command].main(args, uargs)
  File "/home/light/miniconda3/lib/python3.6/site-packages/catalyst-19.6.3-py3.6.egg/catalyst/dl/scripts/run.py", line 76, in main
    dump_code(args.expdir, experiment.logdir)
  File "/home/light/miniconda3/lib/python3.6/site-packages/catalyst-19.6.3-py3.6.egg/catalyst/utils/scripts.py", line 43, in dump_code
    _tricky_dir_copy(old_expdir, new_expdir)
  File "/home/light/miniconda3/lib/python3.6/site-packages/catalyst-19.6.3-py3.6.egg/catalyst/utils/scripts.py", line 27, in _tricky_dir_copy
    shutil.rmtree(dir_to)
  File "/home/light/miniconda3/lib/python3.6/shutil.py", line 490, in rmtree
    onerror(os.rmdir, path, sys.exc_info())
  File "/home/light/miniconda3/lib/python3.6/shutil.py", line 488, in rmtree
    os.rmdir(path)
OSError: [Errno 22] Invalid argument: '/tmp/catalyst/resnet34//code/z/./'
```
It is because of very strange code in catalyst/utils/scripts.py:
```
    old_pro_dir = os.path.dirname(os.path.abspath(__file__)) + "/../"
    new_pro_dir = logdir + f"/{new_src_dir}/catalyst/"
    _tricky_dir_copy(old_pro_dir, new_pro_dir)

    old_expdir = os.path.abspath(expdir)
    expdir_ = expdir.rsplit("/", 1)[-1]
    new_expdir = logdir + f"/{new_src_dir}/{expdir_}/"
    _tricky_dir_copy(old_expdir, new_expdir)
```

Line 27 the same file:

```
shutil.rmtree(dir_to) # Does not accept the ending './'
```

