### PR TITLE
empty config None error merge dicts fix

### DIFF
--- a/catalyst/utils/misc.py
+++ b/catalyst/utils/misc.py
@@ -54,6 +54,7 @@ def merge_dicts(*dicts: dict) -> dict:
     dict_ = copy.deepcopy(dicts[0])
 
     for merge_dict in dicts[1:]:
+        merge_dict = merge_dict or {}
         for k, v in merge_dict.items():
             if (
                 k in dict_ and isinstance(dict_[k], dict)


### PR DESCRIPTION
I have 3-tiers config project.
Some of configs in the second layer are empty.
I use this script to run the training:

```
#!/usr/bin/env bash

children=($( ls $1/child))
for (( i=1; i<${#children[@]}+1; i++ ));
do
    file=${children[$i-1]}
    echo $i " / " ${#children[@]} " : " $file

    PYTHONPATH=~/projects/mlcomp/ catalyst-dl \
    run --config configs/base.yml $1/base.yml $1/child/$file \
    --logdir "/tmp/catalyst/$1/"$file/ "${@:2}"

    echo
    echo
done
```

In that case, I am getting:
```
Traceback (most recent call last):
  File "/home/light/miniconda3/bin/catalyst-dl", line 11, in <module>
    load_entry_point('catalyst==19.6.3', 'console_scripts', 'catalyst-dl')()
  File "/home/light/projects/catalyst/catalyst/dl/__main__.py", line 43, in main
    COMMANDS[args.command].main(args, uargs)
  File "/home/light/projects/catalyst/catalyst/dl/scripts/run.py", line 66, in main
    args, config = parse_args_uargs(args, unknown_args)
  File "/home/light/projects/catalyst/catalyst/utils/config.py", line 135, in parse_args_uargs
    config = merge_dicts(config, config_)
  File "/home/light/projects/catalyst/catalyst/utils/misc.py", line 57, in merge_dicts
    for k, v in merge_dict.items():
AttributeError: 'NoneType' object has no attribute 'items'
```

The reason: if the config is empty, yml parser returns None. config.py:132