### PR TITLE
fix numpy-skimage versions mismatch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ torch>=0.4.1
 torchvision>=0.2.1
 imageio
 opencv-python
-scikit-image>=1.14.2
+scikit-image>=0.14.2
 tqdm>=4.29.1
 PyYAML
 tensorboardX>=1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ torch>=0.4.1
 torchvision>=0.2.1
 imageio
 opencv-python
-scikit-image
+scikit-image>=1.14.2
 tqdm>=4.29.1
 PyYAML
 tensorboardX>=1.6


### PR DESCRIPTION
With scikit-image<0.14.2 line `from catalyst.dl import SupervisedRunner` was unable to be run and failed with following error message:
```
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-4-6cf9792cf866> in <module>
      1 import torch
----> 2 from catalyst.dl import SupervisedRunner

~/.local/lib/python3.6/site-packages/catalyst/dl/__init__.py in <module>
      1 # flake8: noqa
      2 
----> 3 from .callbacks import CriterionCallback, OptimizerCallback, SchedulerCallback, \
      4     CheckpointCallback, EarlyStoppingCallback, ConfusionMatrixCallback, \
      5     AccuracyCallback, MapKCallback, AUCCallback, \

~/.local/lib/python3.6/site-packages/catalyst/dl/callbacks/__init__.py in <module>
      1 # flake8: noqa
      2 
----> 3 from .metrics import AccuracyCallback, MapKCallback, \
      4     AUCCallback, DiceCallback, F1ScoreCallback, IouCallback, JaccardCallback
      5 

~/.local/lib/python3.6/site-packages/catalyst/dl/callbacks/metrics/__init__.py in <module>
      1 # flake8: noqa
      2 
----> 3 from .accuracy import AccuracyCallback, MapKCallback
      4 from .auc import AUCCallback
      5 from .dice import DiceCallback

~/.local/lib/python3.6/site-packages/catalyst/dl/callbacks/metrics/accuracy.py in <module>
      1 from typing import List
      2 
----> 3 from catalyst.dl.core import MultiMetricCallback
      4 from catalyst.dl.utils import criterion
      5 

~/.local/lib/python3.6/site-packages/catalyst/dl/core/__init__.py in <module>
      1 # flake8: noqa
      2 
----> 3 from .callback import Callback, MetricCallback, MultiMetricCallback
      4 from .experiment import Experiment
      5 from .runner import Runner

~/.local/lib/python3.6/site-packages/catalyst/dl/core/callback.py in <module>
      1 from typing import Callable, List
----> 2 from .state import RunnerState
      3 
      4 
      5 class Callback:

~/.local/lib/python3.6/site-packages/catalyst/dl/core/state.py in <module>
      4 from torch.optim.optimizer import Optimizer
      5 
----> 6 from catalyst.utils.frozen import FrozenClass
      7 from .metric_manager import MetricManager, TimerManager
      8 

~/.local/lib/python3.6/site-packages/catalyst/utils/__init__.py in <module>
     12 # from .frozen import *
     13 from .hash import get_hash, get_short_hash
---> 14 from .image import imread, tensor_from_rgb_image, tensor_to_ndimage, \
     15     binary_mask_to_overlay_image
     16 from .initialization import create_optimal_inner_init, outer_init, \

~/.local/lib/python3.6/site-packages/catalyst/utils/image.py in <module>
      5 import numpy as np
      6 import imageio
----> 7 from skimage.color import label2rgb, rgb2gray
      8 
      9 import torch

~/.local/lib/python3.6/site-packages/skimage/__init__.py in <module>
    165         _raise_build_error(e)
    166     # All skimage root imports go here
--> 167     from .util.dtype import (img_as_float32,
    168                              img_as_float64,
    169                              img_as_float,

~/.local/lib/python3.6/site-packages/skimage/util/__init__.py in <module>
      6 from .apply_parallel import apply_parallel
      7 
----> 8 from .arraycrop import crop
      9 from ._regular_grid import regular_grid, regular_seeds
     10 from .unique import unique_rows

~/.local/lib/python3.6/site-packages/skimage/util/arraycrop.py in <module>
      6 
      7 import numpy as np
----> 8 from numpy.lib.arraypad import _validate_lengths
      9 
     10 

ImportError: cannot import name '_validate_lengths'
```
It was caused by deleting function `_validate_lengths` from numpy. This was fixed in scikit-image==0.14.2 which means you need to have skimage version at least 0.14.2 if you are using latest numpy.