### PR TITLE
Print LR metric in scientific notation

### DIFF
--- a/catalyst/dl/utils/formatters.py
+++ b/catalyst/dl/utils/formatters.py
@@ -45,7 +45,7 @@ class TxtMetricsFormatter(MetricsFormatter):
         super().__init__("[{asctime}] ")
 
     def _format_metric(self, name, value):
-        if name in {'_base/lr'}:
+        if name in {"_base/lr"}:
             # Print LR in scientific format since
             # 4 decimal chars is not enough for LR
             # lower than 1e-5

--- a/catalyst/dl/utils/formatters.py
+++ b/catalyst/dl/utils/formatters.py
@@ -45,10 +45,10 @@ class TxtMetricsFormatter(MetricsFormatter):
         super().__init__("[{asctime}] ")
 
     def _format_metric(self, name, value):
-        if name in {"_base/lr"}:
+        if value < 1e-4:
             # Print LR in scientific format since
             # 4 decimal chars is not enough for LR
-            # lower than 1e-5
+            # lower than 1e-4
             return f"{name}={value:E}"
 
         return f"{name}={value:.4f}"

--- a/catalyst/dl/utils/formatters.py
+++ b/catalyst/dl/utils/formatters.py
@@ -44,12 +44,21 @@ class TxtMetricsFormatter(MetricsFormatter):
     def __init__(self):
         super().__init__("[{asctime}] ")
 
+    def _format_metric(self, name, value):
+        if name in {'_base/lr'}:
+            # Print LR in scientific format since
+            # 4 decimal chars is not enough for LR
+            # lower than 1e-5
+            return f"{name}={value:E}"
+
+        return f"{name}={value:.4f}"
+
     def _format_metrics(self, metrics):
         # metrics : dict[str: dict[str: float]]
         metrics_formatted = {}
         for key, value in metrics.items():
             metrics_formatted_ = [
-                f"{m_name}={m_value:.4f}"
+                self._format_metric(m_name, m_value)
                 for m_name, m_value in sorted(value.items())
             ]
             metrics_formatted_ = " | ".join(metrics_formatted_)


### PR DESCRIPTION
Fixes `_base/lr=0.0000` in logs when LR is 1e-5 and lower