### PR TITLE
fixing softmax dim for attention pooling

### DIFF
--- a/rl/networks/agents.py
+++ b/rl/networks/agents.py
@@ -81,7 +81,7 @@ class LamaActor(nn.Module):
                 out_channels=1,
                 kernel_size=1,
                 bias=True),
-            nn.Softmax(dim=1))
+            nn.Softmax(dim=2))
         self.feature_net2 = SequentialNet(
             hiddens=[hiddens[-1] * 4, hiddens[-1]],
             layer_fn=layer_fn,


### PR DESCRIPTION
Hello,
with the most recent version of pytorch the attention pooling of the LAMA-actor in https://github.com/Scitator/neurips-18-prosthetics-challenge (catalyst@ aefc813) is broken. The softmax function is computed on the wrong dimension.

In the following picture the attention pooling yields 1 for each of the 4 observations due to the above: 
![Screenshot(softmax=dim1)](https://user-images.githubusercontent.com/43953203/62477145-a3ae2b00-b7a8-11e9-9b5e-6f31f9970341.png)

Computing softmax with dim=2 fixes this issue:
![Screenshot_softmax(dim=2)](https://user-images.githubusercontent.com/43953203/62477175-b45ea100-b7a8-11e9-84ac-8cdb5ed2faa0.png)

Co-authored-by: Andrew Melnik <andrew.melnik.git@gmail.com>