### PR TITLE
rename get_model_params and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,12 @@ Break the cycle - use the Catalyst!
 
 Catalyst is compatible with: Python 3.6+. PyTorch 0.4.1+.
 
-API documentation and an overview of the library can be found 
-[here](https://catalyst-team.github.io/catalyst/index.html).
+#### Docs and examples
+- Detailed [classification tutorial](./examples/notebooks/classification-tutorial.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/catalyst-team/catalyst/blob/master/examples/notebooks/classification-tutorial.ipynb)
+- Comprehensive [classification pipeline](https://github.com/catalyst-team/classification).
+
+API documentation and an overview of the library can be found here
+[![Docs](https://img.shields.io/badge/dynamic/json.svg?label=docs&url=https%3A%2F%2Fpypi.org%2Fpypi%2Fcatalyst%2Fjson&query=%24.info.version&colorB=brightgreen&prefix=v)](https://catalyst-team.github.io/catalyst/index.html).
 
 In the [examples folder](examples) 
 of the repository, you can find advanced tutorials and Catalyst best practices.

--- a/catalyst/dl/callbacks/metrics/accuracy.py
+++ b/catalyst/dl/callbacks/metrics/accuracy.py
@@ -9,15 +9,24 @@ def _get_default_accuracy_args(num_classes: int) -> List[int]:
     Calculate list params for Accuracy@k and mAP@k
     Args:
         num_classes (int): number of classes
+
+    Returns:
+        iterable: array of accuracy arguments
+
+    Examples:
+        >>> _get_default_accuracy_args(num_classes=4)
+        >>> [1, 3]
+        >>> _get_default_accuracy_args(num_classes=8)
+        >>> [1, 3, 5]
     """
     result = [1]
 
     if num_classes is None:
         return result
 
-    if num_classes >= 3:
+    if num_classes > 3:
         result.append(3)
-    if num_classes >= 5:
+    if num_classes > 5:
         result.append(5)
 
     return result

--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -15,7 +15,7 @@ from catalyst.utils.misc import merge_dicts
 from catalyst.utils.hash import get_short_hash
 from catalyst.dl.core import Experiment, Callback
 from catalyst.dl.utils.torch import _Model, _Criterion, _Optimizer, \
-    _Scheduler, get_model_params
+    _Scheduler, process_model_params
 
 
 class ConfigExperiment(Experiment):
@@ -168,7 +168,7 @@ class ConfigExperiment(Experiment):
 
         weight_decay: float = optimizer_params.get("weight_decay", 0.0)
         no_bias_weight_decay = optimizer_params.pop("no_bias_weight_decay", True)
-        model_params = get_model_params(
+        model_params = process_model_params(
             model, weight_decay, no_bias_weight_decay
         )
         # Linear scaling rule from https://arxiv.org/pdf/1706.02677.pdf

--- a/catalyst/dl/utils/torch.py
+++ b/catalyst/dl/utils/torch.py
@@ -99,7 +99,7 @@ def get_loader(
     return loader
 
 
-def get_model_params(
+def process_model_params(
     model: _Model,
     weight_decay: float = 0.0,
     no_bias_weight_decay: bool = True
@@ -118,7 +118,7 @@ def get_model_params(
 
     Examples:
         >>> model = ResnetUnet()
-        >>> params = get_model_params(model, weight_decay=0.00001)
+        >>> params = process_model_params(model, weight_decay=0.00001)
         >>> optimizer = torch.optim.Adam(params, lr=0.0003)
     """
     params = list(model.named_parameters())
@@ -141,6 +141,6 @@ def get_model_params(
 
 
 __all__ = [
-    "process_components", "get_loader", "get_model_params",
+    "process_components", "get_loader", "process_model_params",
     "_Model", "_Criterion", "_Optimizer", "_Scheduler"
 ]

--- a/examples/notebooks/classification-tutorial.ipynb
+++ b/examples/notebooks/classification-tutorial.ipynb
@@ -19,7 +19,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "!pip install -U catalyst\n",
@@ -201,7 +203,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "load_data(dataset=DATASET)"
@@ -269,7 +273,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "images = read_random_images(ALL_IMAGES)\n",
@@ -370,7 +376,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "from catalyst.utils.pandas import map_dataframe\n",
@@ -422,7 +430,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "len(train_data), len(valid_data)"
@@ -883,7 +893,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "runner.train(\n",
@@ -924,7 +936,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "# it can take a while (colab issue)\n",
@@ -1061,7 +1075,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "runner.train(\n",
@@ -1157,7 +1173,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "runner.train(\n",
@@ -1187,7 +1205,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "# it can take a while (colab issue)\n",
@@ -1239,7 +1259,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "predictions.shape"
@@ -1285,33 +1307,24 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.3"
-  },
-  "pycharm": {
-   "stem_cell": {
-    "cell_type": "raw",
-    "metadata": {
-     "collapsed": false
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
     },
-    "source": []
-   }
-  }
- },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.7.0"
+    }
+  },
  "nbformat": 4,
  "nbformat_minor": 2
 }

--- a/examples/notebooks/classification-tutorial.ipynb
+++ b/examples/notebooks/classification-tutorial.ipynb
@@ -1245,7 +1245,7 @@
    "outputs": [],
    "source": [
     "predictions = runner.predict_loader(\n",
-    "    loaders[\"valid\"], resume=f\"{logdir}/checkpoints/best.pth\"\n",
+    "    loaders[\"valid\"], resume=f\"{logdir}/checkpoints/best.pth\", verbose=True\n",
     ")"
    ]
   },

--- a/examples/notebooks/classification-tutorial.ipynb
+++ b/examples/notebooks/classification-tutorial.ipynb
@@ -1300,7 +1300,10 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "label = probabilities.argmax().item()\n",
+    "print(f\"predicted: {class_names[label]}\")\n"
+   ]
   }
  ],
   "metadata": {

--- a/examples/notebooks/classification-tutorial.ipynb
+++ b/examples/notebooks/classification-tutorial.ipynb
@@ -19,9 +19,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "!pip install -U catalyst\n",
@@ -203,9 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "load_data(dataset=DATASET)"
@@ -273,9 +269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "images = read_random_images(ALL_IMAGES)\n",
@@ -376,9 +370,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from catalyst.utils.pandas import map_dataframe\n",
@@ -430,9 +422,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "len(train_data), len(valid_data)"
@@ -893,9 +883,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "runner.train(\n",
@@ -936,9 +924,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# it can take a while (colab issue)\n",
@@ -1075,9 +1061,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "runner.train(\n",
@@ -1173,9 +1157,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "runner.train(\n",
@@ -1205,9 +1187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# it can take a while (colab issue)\n",
@@ -1259,9 +1239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "predictions.shape"

--- a/examples/notebooks/classification-tutorial.ipynb
+++ b/examples/notebooks/classification-tutorial.ipynb
@@ -11,6 +11,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Requirements\n",
+    "\n",
+    "Download and install the latest version of catalyst and other libraries required for this tutorial."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "!pip install -U catalyst\n",
+    "!pip install albumentations\n",
+    "!pip install pretrainedmodels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Colab extras\n",
     "\n",
     "First of all, do not forget to change the runtime type to GPU. <br/>\n",
@@ -44,28 +66,6 @@
     "\n",
     "\n",
     "IPython.get_ipython().events.register('pre_run_cell', configure_plotly_browser_state)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Requirements\n",
-    "\n",
-    "Download and install the latest version of catalyst and other libraries required for this tutorial."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "!pip install -U catalyst\n",
-    "!pip install albumentations\n",
-    "!pip install pretrainedmodels"
    ]
   },
   {
@@ -1306,25 +1306,34 @@
    ]
   }
  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.7.0"
-    }
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
   },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "metadata": {
+     "collapsed": false
+    },
+    "source": []
+   }
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 2
 }

--- a/examples/notebooks/classification-tutorial.ipynb
+++ b/examples/notebooks/classification-tutorial.ipynb
@@ -777,8 +777,9 @@
    "outputs": [],
    "source": [
     "from torch import nn\n",
-    "def get_model(model_name: str, num_classes: int):\n",
-    "    model = pretrainedmodels.__dict__[model_name](num_classes=1000, pretrained='imagenet')\n",
+    "def get_model(model_name: str, num_classes: int, pretrained: str = \"imagenet\"):\n",
+    "    model_fn = pretrainedmodels.__dict__[model_name]\n",
+    "    model = model_fn(num_classes=1000, pretrained=pretrained)\n",
     "    \n",
     "    dim_feats = model.last_linear.in_features\n",
     "    model.last_linear = nn.Linear(dim_feats, num_classes)\n",

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,7 +8,7 @@ scikit-image>=0.14.2
 tqdm>=4.29.1
 PyYAML
 tensorboardX>=1.6
-plotly>=3.6.1
+plotly>=4.1.0
 torchnet
 safitty>=1.2.3
 crc32c>=1.7


### PR DESCRIPTION
- Added to README our tutorials and pipelines
- fixed `_get_default_accuracy_args`. Previously if we only had 5 classes we saw constant `accuracy05 = 100%` which is not necessary.
- renamed `get_model_params` to `process_model_params` to comply with the Catalyst's standards.
- added `pretrained: str = "imagenet"` to the tutorial
- added `verbose=True` flag to `predict_loader`
- added predicted class name after `predict_loader`
- fixed `plotly` in google colab