### PR TITLE
Specify number of decimal digits when printing in scientific format.

### DIFF
--- a/catalyst/dl/callbacks/logging.py
+++ b/catalyst/dl/callbacks/logging.py
@@ -41,7 +41,7 @@ class VerboseLogger(Callback):
     def on_batch_end(self, state: RunnerState):
         self.tqdm.set_postfix(
             **{
-                k: "{:3.3f}".format(v)
+                k: "{:3.3f}".format(v) if v > 1e-3 else "{:1.3e}".format(v)
                 for k, v in sorted(state.metrics.batch_values.items())
                 if self._need_show(k)
             }

--- a/catalyst/dl/utils/formatters.py
+++ b/catalyst/dl/utils/formatters.py
@@ -49,7 +49,7 @@ class TxtMetricsFormatter(MetricsFormatter):
             # Print LR in scientific format since
             # 4 decimal chars is not enough for LR
             # lower than 1e-4
-            return f"{name}={value:E}"
+            return f"{name}={value:1.3e}"
 
         return f"{name}={value:.4f}"
 


### PR DESCRIPTION
This makes metrics looks like 0.123e-4 instead of 0.1230000e-4