### PR TITLE
add segmentation models to init

### DIFF
--- a/catalyst/contrib/models/__init__.py
+++ b/catalyst/contrib/models/__init__.py
@@ -1,2 +1,4 @@
 # flake8: noqa
 from .sequential import *
+from .segmentation import Unet, Linknet, FPNUnet, PSPnet, \
+    ResnetUnet, ResnetLinknet, ResnetFPNUnet, ResnetPSPnet


### PR DESCRIPTION
add segmentation models to `__init__.py` and now the will be registered automatically in
```
def _model_loader(r: Registry):
    from catalyst.contrib import models as m
    r.add_from_module(m)
```