### PR TITLE
[proposal – catalyst.data] Paths dataset that derives labels from filenames

### DIFF
--- a/catalyst/data/dataset.py
+++ b/catalyst/data/dataset.py
@@ -112,4 +112,28 @@ class MergeDataset(Dataset):
         return self.len
 
 
-__all__ = ["ListDataset", "MergeDataset"]
+class PathsDataset(ListDataset):
+    """
+    Dataset that derives features and targets from samples filesystem paths.
+    """
+    def __init__(
+        self,
+        filenames: List[Dict],
+        open_fn: Callable,
+        get_label_fn: Callable,
+        **list_dataset_params
+    ):
+        list_data = [
+            {'features': filename, 
+             'targets': get_label_fn(filename)}
+            for filename in filenames]
+        
+        super().__init__(
+            list_data=list_data,
+            open_fn=open_fn,
+            **list_dataset_params
+        )
+
+
+__all__ = ["ListDataset", "MergeDataset", "PathsDataset"]
+

--- a/catalyst/data/dataset.py
+++ b/catalyst/data/dataset.py
@@ -123,10 +123,27 @@ class PathsDataset(ListDataset):
         get_label_fn: Callable,
         **list_dataset_params
     ):
+        """
+         Args:
+            filenames (List[Dict]): list of files that store information
+                about your dataset samples; it could be images, texts or
+                any other files in general.
+            open_fn (callable): function, that can open your
+                annotations dict and
+                transfer it to data, needed by your network
+                (for example open image by path, or tokenize read string.)
+            get_label_fn (callable): function, that can extract target
+                value from sample path
+                (for example, your sample could be an image file like
+                /path/to/your/image_1.png where the targer is encoded as
+                a part of file path.
+            list_dataset_params (dict): base class initialization 
+                parameters.
+        """
         list_data = [
-            {'features': filename, 
-             'targets': get_label_fn(filename)}
-            for filename in filenames]
+            dict(features=filename, targets=get_label_fn(filename))
+            for filename in filenames
+        ]
         
         super().__init__(
             list_data=list_data,

--- a/catalyst/data/dataset.py
+++ b/catalyst/data/dataset.py
@@ -137,14 +137,14 @@ class PathsDataset(ListDataset):
                 (for example, your sample could be an image file like
                 /path/to/your/image_1.png where the targer is encoded as
                 a part of file path.
-            list_dataset_params (dict): base class initialization 
+            list_dataset_params (dict): base class initialization
                 parameters.
         """
         list_data = [
             dict(features=filename, targets=get_label_fn(filename))
             for filename in filenames
         ]
-        
+
         super().__init__(
             list_data=list_data,
             open_fn=open_fn,
@@ -153,4 +153,3 @@ class PathsDataset(ListDataset):
 
 
 __all__ = ["ListDataset", "MergeDataset", "PathsDataset"]
-


### PR DESCRIPTION
Recently I decided to try `catalyst` in my projects, and I encountered the following case. In one of the datasets I am working on, the samples include labels as a part of file paths, like this.
```
\folder
    \with
        \samples
            \filename1_1.png
            \filename2_1.png
            \filename3_3.png
            \filename4_2.png
            ...
```
In `fastai` there are various datasets factories that can read features and targets from data frame columns, file paths, using lambda functions, etc. I decided to implement something similar for my case. Then, you can do as follows.
```python
import os
import re
import PIL.Image

class RegexLabelExtractor:
    def __init__(self, regex):
        self.regex = re.compile(regex)

    def __call__(self, filename):
        return int(self.regex.match(os.path.basename(filename)).group(1))

def list_files(folder):
    dirname = os.path.expanduser(folder)
    return [os.path.join(dirname, x) for x in os.listdir(dirname)]

def open_image(dict_):
    dict_['features'] = PIL.Image.open(dict_['features'])
    return dict_

dataset = FilesDataset(
    filenames=list_files('~/folder/with/samples'),
    open_fn=open_image,
    get_label_fn=RegexLabelExtractor('.*_(\d+)\\.png$'),
)    
```
In this PR, I propose to include something like this into `catalyst`. This implementation is pretty rough, so probably a better, or more generic solution could be implemented. (I am not sure if the proposed dataset implementation fits to the logic of the `catalyst` codebase). What do you think?

Thank you.