### PR TITLE
Accuracy callback fix

### DIFF
--- a/catalyst/dl/utils/criterion/accuracy.py
+++ b/catalyst/dl/utils/criterion/accuracy.py
@@ -10,7 +10,7 @@ def accuracy(outputs, targets, topk=(1, )):
 
     _, pred = outputs.topk(max_k, 1, True, True)
     pred = pred.t()
-    correct = pred.eq(targets.view(1, -1).expand_as(pred))
+    correct = pred.eq(targets.long().view(1, -1).expand_as(pred))
 
     res = []
     for k in topk:


### PR DESCRIPTION
Code for reproduce:

```
import torch
from torch import nn
from torch.optim import Adam
from torch.utils.data import Dataset, DataLoader
from torchvision.models import mobilenet_v2

import catalyst
from catalyst.dl import SupervisedRunner, AccuracyCallback

print(torch.__version__)
print(catalyst.__version__)


class _Dataset(Dataset):
    def __len__(self):
        return 1

    def __getitem__(self, item):
        return {'features': torch.rand((3, 256, 1600)), 'targets': torch.Tensor([0])}


dataloader = DataLoader(_Dataset())

model = mobilenet_v2(False, num_classes=1)
runner = SupervisedRunner()
optim = Adam(model.parameters())
runner.train(model, nn.BCEWithLogitsLoss(), optim, {'train': dataloader, 'valid': dataloader}, 'test',
             callbacks=[AccuracyCallback()]
             )

```

Output:
```
1.2.0
19.08.7
Traceback (most recent call last):
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/runner/supervised.py", line 131, in train
    self.run_experiment(experiment, check=check)
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/core/runner.py", line 196, in run_experiment
    self._run_event("exception")
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/core/runner.py", line 96, in _run_event
    getattr(self.state, f"on_{event}_post")()
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/core/state.py", line 173, in on_exception_post
    logger.on_exception(self)
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/callbacks/logging.py", line 189, in on_exception
    raise exception
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/core/runner.py", line 193, in run_experiment
    self._run_stage(stage)
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/core/runner.py", line 175, in _run_stage
    self._run_epoch(loaders)
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/core/runner.py", line 162, in _run_epoch
    self._run_loader(loader)
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/core/runner.py", line 131, in _run_loader
    self._run_batch(batch)
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/core/runner.py", line 113, in _run_batch
    self._run_event("batch_end")
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/core/runner.py", line 93, in _run_event
    getattr(callback, f"on_{event}")(self.state)
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/core/callback.py", line 105, in on_batch_end
    outputs, targets, self.list_args, **self.metric_params
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/utils/criterion/accuracy.py", line 13, in accuracy
    correct = pred.eq(targets.view(1, -1).expand_as(pred))
RuntimeError: Expected object of scalar type Long but got scalar type Float for argument #2 'other'
```