### PR TITLE
Fixed OptimizerCallback call before CriterionCallback

### DIFF
--- a/catalyst/dl/experiment/supervised.py
+++ b/catalyst/dl/experiment/supervised.py
@@ -23,7 +23,7 @@ class SupervisedExperiment(BaseExperiment):
                     continue
 
                 present_callbacks = [(key, val) for key, val in
-                                     callbacks.items() if
+                                     self._callbacks.items() if
                                      isinstance(val, callback_fn)]
 
                 if present_callbacks:

--- a/catalyst/dl/experiment/supervised.py
+++ b/catalyst/dl/experiment/supervised.py
@@ -9,7 +9,7 @@ from catalyst.dl.callbacks import \
 
 class SupervisedExperiment(BaseExperiment):
     def get_callbacks(self, stage: str) -> "OrderedDict[str, Callback]":
-        callbacks = self._callbacks
+        callbacks = OrderedDict(())
         if not stage.startswith("infer"):
             default_callbacks = [
                 (self._criterion, "_criterion", CriterionCallback),
@@ -19,10 +19,17 @@ class SupervisedExperiment(BaseExperiment):
             ]
 
             for component, callback_name, callback_fn in default_callbacks:
-                is_already_present = any(
-                    isinstance(x, callback_fn) for x in callbacks.values()
-                )
-                if component is not None and not is_already_present:
+                if component is None:
+                    continue
+
+                present_callbacks = [(key, val) for key, val in
+                                     callbacks.items() if
+                                     isinstance(val, callback_fn)]
+
+                if present_callbacks:
+                    for key, val in present_callbacks:
+                        callbacks[key] = val
+                else:
                     callbacks[callback_name] = callback_fn()
         return callbacks
 


### PR DESCRIPTION
Code for reproduce:
```
import torch
from torch import nn
from torch.optim import Adam
from torch.utils.data import Dataset, DataLoader
from torchvision.models import mobilenet_v2

import catalyst
from catalyst.dl import SupervisedRunner, OptimizerCallback

print(torch.__version__)
print(catalyst.__version__)


class _Dataset(Dataset):
    def __len__(self):
        return 1

    def __getitem__(self, item):
        return {'features': torch.rand((3, 256, 1600)), 'targets': torch.Tensor([0])}


dataloader = DataLoader(_Dataset())

model = mobilenet_v2(False, num_classes=1)
runner = SupervisedRunner()
optim = Adam(model.parameters())
runner.train(model, nn.BCEWithLogitsLoss(), optim, {'train': dataloader, 'valid': dataloader}, 'test',
             callbacks=[OptimizerCallback(accumulation_steps=2)]
             )

```

Output:
```
1.2.0
19.08.7
Traceback (most recent call last):
    callbacks=[OptimizerCallback(accumulation_steps=2)]
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/runner/supervised.py", line 131, in train
    self.run_experiment(experiment, check=check)
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/core/runner.py", line 196, in run_experiment
    self._run_event("exception")
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/core/runner.py", line 96, in _run_event
    getattr(self.state, f"on_{event}_post")()
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/core/state.py", line 173, in on_exception_post
    logger.on_exception(self)
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/callbacks/logging.py", line 189, in on_exception
    raise exception
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/core/runner.py", line 193, in run_experiment
    self._run_stage(stage)
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/core/runner.py", line 175, in _run_stage
    self._run_epoch(loaders)
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/core/runner.py", line 162, in _run_epoch
    self._run_loader(loader)
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/core/runner.py", line 131, in _run_loader
    self._run_batch(batch)
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/core/runner.py", line 113, in _run_batch
    self._run_event("batch_end")
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/core/runner.py", line 93, in _run_event
    getattr(callback, f"on_{event}")(self.state)
  File "/mnt/HDD/home/druzhinin/GitRepos/catalyst/catalyst/dl/callbacks/optimizer.py", line 111, in on_batch_end
    loss.backward()
AttributeError: 'NoneType' object has no attribute 'backward'
```