### PR TITLE
fix/lovasz view(-1) replaced to reshape(-1)

### DIFF
--- a/catalyst/contrib/criterion/lovasz.py
+++ b/catalyst/contrib/criterion/lovasz.py
@@ -61,8 +61,8 @@ def _flatten_binary_scores(logits, targets, ignore=None):
     Flattens predictions in the batch (binary case)
     Remove targets equal to "ignore"
     """
-    logits = logits.view(-1)
-    targets = targets.view(-1)
+    logits = logits.reshape(-1)
+    targets = targets.reshape(-1)
     if ignore is None:
         return logits, targets
     valid = (targets != ignore)

--- a/catalyst/contrib/criterion/lovasz.py
+++ b/catalyst/contrib/criterion/lovasz.py
@@ -166,7 +166,7 @@ def _lovasz_softmax_flat(probabilities, targets, classes="present"):
         if classes == "present" and fg.sum() == 0:
             continue
         if C == 1:
-            if len(classes) > 1:
+            if len(class_to_sum) > 1:
                 raise ValueError("Sigmoid output possible only with 1 class")
             class_pred = probabilities[:, 0]
         else:

--- a/examples/_tests_scripts/z_segmentation.py
+++ b/examples/_tests_scripts/z_segmentation.py
@@ -7,6 +7,7 @@
 # In[ ]:
 
 import matplotlib
+
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 plt.ioff()
@@ -34,9 +35,42 @@ import torchvision
 import torchvision.transforms as transforms
 from catalyst.data import Augmentor
 from catalyst.dl import utils
+from catalyst.contrib.criterion import LovaszLossBinary, \
+    LovaszLossMultiLabel, \
+    LovaszLossMultiClass
 
 bs = 1
 num_workers = 0
+
+
+def get_loaders(transform):
+    open_fn = lambda x: {"features": x[0], "targets": x[1]}
+
+    loaders = collections.OrderedDict()
+
+    train_loader = utils.get_loader(
+        train_data,
+        open_fn=open_fn,
+        dict_transform=transform,
+        batch_size=bs,
+        num_workers=num_workers,
+        shuffle=True
+    )
+
+    valid_loader = utils.get_loader(
+        valid_data,
+        open_fn=open_fn,
+        dict_transform=transform,
+        batch_size=bs,
+        num_workers=num_workers,
+        shuffle=False
+    )
+
+    loaders["train"] = train_loader
+    loaders["valid"] = valid_loader
+
+    return loaders
+
 
 data_transform = transforms.Compose([
     Augmentor(
@@ -54,30 +88,7 @@ data_transform = transforms.Compose([
             torch.from_numpy(x.copy().astype(np.float32) / 255.).unsqueeze_(0))
 ])
 
-open_fn = lambda x: {"features": x[0], "targets": x[1]}
-
-loaders = collections.OrderedDict()
-
-train_loader = utils.get_loader(
-    train_data,
-    open_fn=open_fn,
-    dict_transform=data_transform,
-    batch_size=bs,
-    num_workers=num_workers,
-    shuffle=True
-)
-
-valid_loader = utils.get_loader(
-    valid_data,
-    open_fn=open_fn,
-    dict_transform=data_transform,
-    batch_size=bs,
-    num_workers=num_workers,
-    shuffle=False
-)
-
-loaders["train"] = train_loader
-loaders["valid"] = valid_loader
+loaders = get_loaders(data_transform)
 
 # # Model
 
@@ -157,3 +168,96 @@ for i, (input, output) in enumerate(zip(valid_data, runner_out)):
     plt.imshow(mask, 'gray')
 
     plt.show()
+
+# lovasz LovaszLossBinary criterion
+
+criterion = LovaszLossBinary()
+
+runner.train(
+    model=model,
+    criterion=criterion,
+    optimizer=optimizer,
+    loaders=loaders,
+    logdir=logdir,
+    num_epochs=num_epochs,
+    check=True
+)
+
+# Multiclasses checks
+model = Unet(num_classes=2, in_channels=1, num_channels=32, num_blocks=2)
+
+# lovasz LovaszLossMultiClass criterion
+
+data_transform = transforms.Compose([
+    Augmentor(
+        dict_key="features",
+        augment_fn=lambda x: \
+            torch.from_numpy(
+                x.copy().astype(np.float32) / 255.).unsqueeze_(0)),
+    Augmentor(
+        dict_key="features",
+        augment_fn=transforms.Normalize(
+            (0.5,),
+            (0.5,))),
+    Augmentor(
+        dict_key="targets",
+        augment_fn=lambda x: \
+            torch.from_numpy(
+                x.copy().astype(np.float32) / 255.
+            ))
+])
+
+loaders = get_loaders(data_transform)
+
+criterion = LovaszLossMultiClass()
+
+runner.train(
+    model=model,
+    criterion=criterion,
+    optimizer=optimizer,
+    loaders=loaders,
+    logdir=logdir,
+    num_epochs=num_epochs,
+    check=True
+)
+
+# lovasz LovaszLossMultiLabel criterion
+
+
+def transform_targets(x):
+    x1 = x.copy().astype(np.float32)[None]
+    x2 = 255 - x.copy().astype(np.float32)[None]
+    return np.vstack([x1, x2]) / 255.
+
+
+data_transform = transforms.Compose([
+    Augmentor(
+        dict_key="features",
+        augment_fn=lambda x: \
+            torch.from_numpy(
+                x.copy().astype(np.float32) / 255.
+            ).unsqueeze_(0)),
+    Augmentor(
+        dict_key="features",
+        augment_fn=transforms.Normalize(
+            (0.5,),
+            (0.5,))),
+    Augmentor(
+        dict_key="targets",
+        augment_fn=lambda x: \
+            torch.from_numpy(transform_targets(x)))
+])
+
+loaders = get_loaders(data_transform)
+
+criterion = LovaszLossMultiLabel()
+
+runner.train(
+    model=model,
+    criterion=criterion,
+    optimizer=optimizer,
+    loaders=loaders,
+    logdir=logdir,
+    num_epochs=num_epochs,
+    check=True
+)


### PR DESCRIPTION
Without the replacement, I am getting the error:

```
 File "/home/light/projects/catalyst/catalyst/dl/core/runner.py", line 131, in _run_loader
    self._run_batch(batch)
  File "/home/light/projects/catalyst/catalyst/dl/core/runner.py", line 113, in _run_batch
    self._run_event("batch_end")
  File "/home/light/projects/catalyst/catalyst/dl/core/runner.py", line 93, in _run_event
    getattr(callback, f"on_{event}")(self.state)
  File "/home/light/projects/catalyst/catalyst/dl/callbacks/criterion.py", line 52, in on_batch_end
    loss = self._compute_loss(state, criterion) * self.multiplier
  File "/home/light/projects/catalyst/catalyst/dl/callbacks/criterion.py", line 40, in _compute_loss
    state.output[self.output_key], state.input[self.input_key]
  File "/home/light/anaconda3/lib/python3.7/site-packages/torch/nn/modules/module.py", line 547, in __call__
    result = self.forward(*input, **kwargs)
  File "/home/light/projects/catalyst/catalyst/contrib/criterion/lovasz.py", line 274, in forward
    ) for i in range(logits.shape[1])
  File "/home/light/projects/catalyst/catalyst/contrib/criterion/lovasz.py", line 274, in <listcomp>
    ) for i in range(logits.shape[1])
  File "/home/light/projects/catalyst/catalyst/contrib/criterion/lovasz.py", line 118, in _lovasz_hinge
    *_flatten_binary_scores(logits, targets, ignore)
  File "/home/light/projects/catalyst/catalyst/contrib/criterion/lovasz.py", line 64, in _flatten_binary_scores
    logits = logits.view(-1)
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
```

Pytorch version is 1.2