### PR TITLE
fix - AccuracyCallback for multi-label classification

### DIFF
--- a/catalyst/dl/callbacks/metrics/accuracy.py
+++ b/catalyst/dl/callbacks/metrics/accuracy.py
@@ -37,27 +37,19 @@ class AccuracyCallback(MultiMetricCallback):
     Accuracy metric callback.
 
     It can be used either for
-        - multi-class task, you can use accuracy_args. threshold and activation
-        are not required.
-            - input_key point on tensor: batch_size
-            - output_key point on tensor: batch_size x num_classes
-
-            An example of a configuration(config API):
-                accuracy:
-                  callback: AccuracyCallback
+        - multi-class task:
+            -you can use accuracy_args.
+            -threshold and activation are not required.
+            -input_key point on tensor: batch_size.
+            -output_key point on tensor: batch_size x num_classes.
         - OR multi-label task, in this case:
-            - you must specify threshold and activation
-            - accuracy_args and num_classes will not be used
+            -you must specify threshold and activation.
+            -accuracy_args and num_classes will not be used
             (because of there is no method to apply top-k in
-             multi-label classification).
-            - input_key, output_key point on tensor: batch_size x num_classes
-            - output_key point on a tensor with binary vectors
+            multi-label classification).
+            -input_key, output_key point on tensor: batch_size x num_classes.
+            -output_key point on a tensor with binary vectors.
 
-            An example of a configuration(config API):
-                accuracy:
-                  callback: AccuracyCallback
-                  threshold: 0.5
-                  activation: Sigmoid
 
     There is no need to choose a type (multi-class/multi label).
     An appropriate type will be chosen automatically via shape of tensors.

--- a/catalyst/dl/callbacks/metrics/accuracy.py
+++ b/catalyst/dl/callbacks/metrics/accuracy.py
@@ -35,6 +35,32 @@ def _get_default_accuracy_args(num_classes: int) -> List[int]:
 class AccuracyCallback(MultiMetricCallback):
     """
     Accuracy metric callback.
+
+    It can be used either for
+        - multi-class task, you can use accuracy_args. threshold and activation
+        are not required.
+            - input_key point on tensor: batch_size
+            - output_key point on tensor: batch_size x num_classes
+
+            An example of a configuration(config API):
+                accuracy:
+                  callback: AccuracyCallback
+        - OR multi-label task, in this case:
+            - you must specify threshold and activation
+            - accuracy_args and num_classes will not be used
+            (because of there is no method to apply top-k in
+             multi-label classification).
+            - input_key, output_key point on tensor: batch_size x num_classes
+            - output_key point on a tensor with binary vectors
+
+            An example of a configuration(config API):
+                accuracy:
+                  callback: AccuracyCallback
+                  threshold: 0.5
+                  activation: Sigmoid
+
+    There is no need to choose a type (multi-class/multi label).
+    An appropriate type will be chosen automatically via shape of tensors.
     """
 
     def __init__(

--- a/catalyst/dl/utils/criterion/accuracy.py
+++ b/catalyst/dl/utils/criterion/accuracy.py
@@ -22,7 +22,7 @@ def accuracy(
         outputs = (outputs > threshold).long()
 
     # multi class classification
-    if targets.size(1) > 1:
+    if len(targets.shape) > 1 and targets.size(1) > 1:
         res = (targets.long() == outputs.long()).sum().float() / np.prod(
             targets.shape)
         return [res]

--- a/catalyst/dl/utils/criterion/accuracy.py
+++ b/catalyst/dl/utils/criterion/accuracy.py
@@ -5,7 +5,7 @@ from catalyst.utils import get_activation_fn
 def accuracy(
         outputs,
         targets,
-        topk=(1, ),
+        topk=(1,),
         threshold: float = None,
         activation: str = None
 ):
@@ -20,6 +20,12 @@ def accuracy(
 
     if threshold:
         outputs = (outputs > threshold).long()
+
+    # multi class classification
+    if targets.size(1) > 1:
+        res = (targets.long() == outputs.long()).sum().float() / np.prod(
+            targets.shape)
+        return [res]
 
     if len(outputs.shape) == 1 or outputs.shape[1] == 1:
         pred = outputs.t()
@@ -65,7 +71,7 @@ def average_accuracy(outputs, targets, k=10):
     return score / min(len(targets), k)
 
 
-def mean_average_accuracy(outputs, targets, topk=(1, )):
+def mean_average_accuracy(outputs, targets, topk=(1,)):
     """
     Computes the mean average accuracy at k.
     This function computes the mean average accuracy at k between two lists

--- a/catalyst/dl/utils/criterion/accuracy.py
+++ b/catalyst/dl/utils/criterion/accuracy.py
@@ -21,7 +21,7 @@ def accuracy(
     if threshold:
         outputs = (outputs > threshold).long()
 
-    # multi class classification
+    # multi-label classification
     if len(targets.shape) > 1 and targets.size(1) > 1:
         res = (targets.long() == outputs.long()).sum().float() / np.prod(
             targets.shape)

--- a/catalyst/dl/utils/criterion/accuracy.py
+++ b/catalyst/dl/utils/criterion/accuracy.py
@@ -10,11 +10,24 @@ def accuracy(
         activation: str = None
 ):
     """
-    Computes the accuracy@k for the specified values of k.
-    """
-    max_k = max(topk)
-    batch_size = targets.size(0)
+    Computes the accuracy.
 
+    It can be used either for
+    - multi-class task, you can use topk. threshold and activation
+    are not required.
+        - targets is a tensor: batch_size
+        - outputs is a tensor: batch_size x num_classes
+
+        Computes the accuracy@k for the specified values of k.
+
+    - OR multi-label task, in this case:
+        - you must specify threshold and activation
+        - topk will not be used
+        (because of there is no method to apply top-k in
+         multi-label classification).
+        - outputs, targets are tensors with shape: batch_size x num_classes
+        - targets is a tensor with binary vectors
+    """
     activation_fn = get_activation_fn(activation)
     outputs = activation_fn(outputs)
 
@@ -26,6 +39,9 @@ def accuracy(
         res = (targets.long() == outputs.long()).sum().float() / np.prod(
             targets.shape)
         return [res]
+
+    max_k = max(topk)
+    batch_size = targets.size(0)
 
     if len(outputs.shape) == 1 or outputs.shape[1] == 1:
         pred = outputs.t()

--- a/catalyst/dl/utils/criterion/accuracy.py
+++ b/catalyst/dl/utils/criterion/accuracy.py
@@ -12,21 +12,20 @@ def accuracy(
     """
     Computes the accuracy.
 
-    It can be used either for
-    - multi-class task, you can use topk. threshold and activation
-    are not required.
-        - targets is a tensor: batch_size
-        - outputs is a tensor: batch_size x num_classes
-
-        Computes the accuracy@k for the specified values of k.
-
-    - OR multi-label task, in this case:
-        - you must specify threshold and activation
-        - topk will not be used
-        (because of there is no method to apply top-k in
-         multi-label classification).
-        - outputs, targets are tensors with shape: batch_size x num_classes
-        - targets is a tensor with binary vectors
+    It can be used either for:
+        - multi-class task:
+            -you can use topk.
+            -threshold and activation are not required.
+            -targets is a tensor: batch_size
+            -outputs is a tensor: batch_size x num_classes
+            -computes the accuracy@k for the specified values of k.
+        - OR multi-label task, in this case:
+            -you must specify threshold and activation
+            -topk will not be used
+            (because of there is no method to apply top-k in
+            multi-label classification).
+            -outputs, targets are tensors with shape: batch_size x num_classes
+            -targets is a tensor with binary vectors
     """
     activation_fn = get_activation_fn(activation)
     outputs = activation_fn(outputs)


### PR DESCRIPTION
criterion/accuracy now can work only with a multi-class classification problem.

Use case: multi-label classification problem

targets: batch_size x num_classes, each sample has binary vector where more than one 1 is possible

outputs: batch_size x num_classes, logits

criterion: BCEWithLogitsLoss

To cope with that, we can check targets.size(1), if it's > 1 that is a multi-class classification problem.

topk can not be applied in that case.