### PR TITLE
Fix: Allow to set config in SupervisedExperiment for wandb

### DIFF
--- a/catalyst/dl/runner/wandb.py
+++ b/catalyst/dl/runner/wandb.py
@@ -55,11 +55,11 @@ class WandbRunner(Runner):
             log_on_epoch_end=log_on_epoch_end,
             checkpoints_glob=checkpoints_glob,
         )
-
-        exp_config = None
         if isinstance(experiment, ConfigExperiment):
             exp_config = utils.flatten_dict(experiment.stages_config)
-        wandb.init(**monitoring_params, config=exp_config)
+            wandb.init(**monitoring_params, config=exp_config)
+        else:
+            wandb.init(**monitoring_params)
 
     def _post_experiment_hook(self, experiment: Experiment):
         logdir_src = Path(experiment.logdir)


### PR DESCRIPTION
Hi, 
First, thanks for the great library. I really love what you did. 

Small change so that when using a `SupervisedExperiment` it is possible to pass a config dictionary to be logged. Before it was failing because `config` was set to `None` by default.

```
 monitoring_params= {
            "project": "clouds",
            "config": {
                "epochs": num_epochs,
                "seed": seed,
                "lr": lr,
                "fp16": fp16,
                "train_tfs": train_tfs,
                "bs": bs
            }
}
```