### PR TITLE
save mixins from extinction

### DIFF
--- a/catalyst/contrib/mixin/blur.py
+++ b/catalyst/contrib/mixin/blur.py
@@ -1,0 +1,52 @@
+from typing import List
+import random
+import numpy as np
+
+import albumentations as A
+
+
+class BlurMixin:
+    """
+    Calculates blur factor for augmented image
+    """
+    def __init__(
+        self,
+        input_key: str = "image",
+        output_key: str = "blur_factor",
+        blur_min: int = 3,
+        blur_max: int = 9,
+        blur: List[str] = None
+    ):
+        """
+        Args:
+            input_key (str): input key to use from annotation dict
+            output_key (str): output key to use to store the result
+        """
+        self.input_key = input_key
+        self.output_key = output_key
+
+        self.blur_min = blur_min
+        self.blur_max = blur_max
+        blur = blur or ["Blur"]
+        self.blur = [A.__dict__[x]() for x in blur]
+        self.num_blur = len(self.blur)
+        self.num_blur_classes = blur_max - blur_min + 1 + 1
+        self.blur_probability = \
+            (self.num_blur_classes - 1) / self.num_blur_classes
+
+    def __call__(self, dictionary):
+        image = dictionary[self.input_key]
+        blur_factor = 0
+
+        if random.random() < self.blur_probability:
+            blur_fn = np.random.choice(self.blur)
+            blur_factor = int(
+                np.random.randint(self.blur_min, self.blur_max) -
+                self.blur_min + 1
+            )
+            image = blur_fn.apply(image=image, ksize=blur_factor)
+
+        dictionary[self.input_key] = image
+        dictionary[self.output_key] = blur_factor
+
+        return dictionary

--- a/catalyst/contrib/mixin/flare.py
+++ b/catalyst/contrib/mixin/flare.py
@@ -1,0 +1,40 @@
+from typing import Dict
+import random
+import albumentations as A
+
+
+class FlareMixin:
+    """
+    Calculates flare factor for augmented image
+    """
+    def __init__(
+        self,
+        input_key: str = "image",
+        output_key: str = "flare_factor",
+        sunflare_params: Dict = None
+    ):
+        """
+        Args:
+            input_key (str): input key to use from annotation dict
+            output_key (str): output key to use to store the result
+            sunflare_params (dict): params to init ``A.RandomSunFlare``
+        """
+        self.input_key = input_key
+        self.output_key = output_key
+
+        self.sunflare_params = sunflare_params or {}
+        self.transform = A.RandomSunFlare(**self.sunflare_params)
+
+    def __call__(self, dictionary):
+        image = dictionary[self.input_key]
+        sunflare_factor = 0
+
+        if random.random() < self.transform.p:
+            params = self.transform.get_params()
+            image = self.transform.apply(image=image, **params)
+            sunflare_factor = 1
+
+        dictionary[self.input_key] = image
+        dictionary[self.output_key] = sunflare_factor
+
+        return dictionary

--- a/catalyst/contrib/mixin/rotate.py
+++ b/catalyst/contrib/mixin/rotate.py
@@ -1,0 +1,62 @@
+import random
+import albumentations as A
+
+from catalyst import utils
+
+
+class RotateMixin:
+    """
+    Calculates rotation factor for augmented image
+    """
+    def __init__(
+        self,
+        input_key: str = "image",
+        output_key: str = "rotation_factor",
+        targets_key: str = None,
+        rotate_probability: float = 1.,
+        hflip_probability: float = 0.5,
+        one_hot_classes: int = None
+    ):
+        """
+        Args:
+            input_key (str): input key to use from annotation dict
+            output_key (str): output key to use to store the result
+        """
+        self.input_key = input_key
+        self.output_key = output_key
+        self.targets_key = targets_key
+        self.rotate_probability = rotate_probability
+        self.hflip_probability = hflip_probability
+        self.rotate = A.RandomRotate90()
+        self.hflip = A.HorizontalFlip()
+        self.one_hot_classes = one_hot_classes * 8 \
+            if one_hot_classes is not None \
+            else None
+
+    def __call__(self, dictionary):
+        image = dictionary[self.input_key]
+        rotation_factor = 0
+
+        if random.random() < self.rotate_probability:
+            rotation_factor = self.rotate.get_params()["factor"]
+            image = self.rotate.apply(img=image, factor=rotation_factor)
+
+        if random.random() < self.hflip_probability:
+            rotation_factor += 4
+            image = self.hflip.apply(img=image)
+
+        dictionary[self.input_key] = image
+        dictionary[self.output_key] = rotation_factor
+
+        if self.targets_key is not None:
+            class_rotation_factor = \
+                dictionary[self.targets_key] * 8 + rotation_factor
+            key = f"class_rotation_{self.targets_key}"
+            dictionary[key] = class_rotation_factor
+
+            if self.one_hot_classes is not None:
+                key = f"class_rotation_{self.targets_key}_one_hot"
+                dictionary[key] = \
+                    utils.get_one_hot(class_rotation_factor, self.one_hot_classes)
+
+        return dictionary

--- a/catalyst/contrib/mixin/rotate.py
+++ b/catalyst/contrib/mixin/rotate.py
@@ -55,8 +55,11 @@ class RotateMixin:
             dictionary[key] = class_rotation_factor
 
             if self.one_hot_classes is not None:
+                one_hot = utils.get_one_hot(
+                    class_rotation_factor,
+                    self.one_hot_classes
+                )
                 key = f"class_rotation_{self.targets_key}_one_hot"
-                dictionary[key] = \
-                    utils.get_one_hot(class_rotation_factor, self.one_hot_classes)
+                dictionary[key] = one_hot
 
         return dictionary


### PR DESCRIPTION
Save useful mixins from catalyst.classification

They use `albumentation` so I cannot add them to a registry, without `albu` in requirements