### PR TITLE
Added nlp-sentiment-tutorial.ipynb

### DIFF
--- a/examples/notebooks/nlp-sentiment-tutorial.ipynb
+++ b/examples/notebooks/nlp-sentiment-tutorial.ipynb
@@ -1,0 +1,2347 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Importing packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-10T11:20:59.284851Z",
+     "start_time": "2019-10-10T11:20:15.792485Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import tensorflow as tf\n",
+    "import numpy as np\n",
+    "from scipy.spatial.distance import cdist\n",
+    "import os\n",
+    "import glob"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-10T11:20:59.293802Z",
+     "start_time": "2019-10-10T11:20:59.287806Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# We need to import several things from Keras.\n",
+    "from tensorflow.python.keras.models import Sequential\n",
+    "from tensorflow.python.keras.layers import Dense, GRU, Embedding\n",
+    "from tensorflow.python.keras.optimizers import Adam\n",
+    "from tensorflow.python.keras.preprocessing.text import Tokenizer\n",
+    "from tensorflow.python.keras.preprocessing.sequence import pad_sequences"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setting up the data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we are using the movie reviews dataset from imdb. That is classified as positive and negative reviews."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can download the dataset from http://ai.stanford.edu/~amaas/data/sentiment/aclImdb_v1.tar.gz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_data(train  = True):\n",
+    "    # Part of the path-name for either train or test-set\n",
+    "    train_test_path = \"train\" if train else \"test\"\n",
+    "    # Base directory where the extracted data is located\n",
+    "    dir_base = os.path.join(data_dir, \"aclImdb\", train_test_path)\n",
+    "    # Filename-patterns for the data-files\n",
+    "    path_pattern_pos = os.path.join(dir_base, \"pos\", \"*.txt\")\n",
+    "    path_pattern_neg = os.path.join(dir_base, \"neg\", \"*.txt\")\n",
+    "\n",
+    "    # Get list of all the file-paths for the data\n",
+    "    path_pos = glob.glob(path_pattern_pos)\n",
+    "    path_neg = glob.glob(path_pattern_neg)\n",
+    "\n",
+    "    # Read all the text_files\n",
+    "    data_pos = [_read_text_file(path) for path in path_pos]\n",
+    "    data_neg = [_read_text_file(path) for path in path_neg]\n",
+    "\n",
+    "    # Concatenate the positive and negative data\n",
+    "    x = data_pos + data_neg\n",
+    "\n",
+    "    # Create a list of the sentiments for the text-data\n",
+    "    # where 1.0 is for positive sentiment and 0.0 is for negative sentiment\n",
+    "\n",
+    "    y = [1.0]*len(data_pos) + [0.0] * len(data_neg)\n",
+    "\n",
+    "    return x,y\n",
+    "\n",
+    "def _read_text_file(path):\n",
+    "    # Read and return alll the content of the text file with the given path\n",
+    "\n",
+    "    with open(path, 'rt', encoding = 'utf-8') as file:\n",
+    "        # Read a list of string\n",
+    "        lines = file.readlines()\n",
+    "\n",
+    "        # Concatenate to a single string.\n",
+    "        text = \" \".join(lines)\n",
+    "\n",
+    "    return text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Saving our data to given location\n",
+    "data_dir = \"**Add your location to dataset**\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_train_text, y_train = load_data(train = True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_test_text, y_test = load_data(train = False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train-set size:  0\n",
+      "Test-set size:  0\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Train-set size: \", len(x_train_text))\n",
+    "print(\"Test-set size: \", len(x_test_text))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "50000\n"
+     ]
+    }
+   ],
+   "source": [
+    "data_text = x_train_text + x_test_text\n",
+    "print(len(data_text))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<b>sample of training data<b>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Brilliant over-acting by Lesley Ann Warren. Best dramatic hobo lady I have ever seen, and love scenes in clothes warehouse are second to none. The corn on face is a classic, as good as anything in Blazing Saddles. The take on lawyers is also superb. After being accused of being a turncoat, selling out his boss, and being dishonest the lawyer of Pepto Bolt shrugs indifferently \"I\\'m a lawyer\" he says. Three funny words. Jeffrey Tambor, a favorite from the later Larry Sanders show, is fantastic here too as a mad millionaire who wants to crush the ghetto. His character is more malevolent than usual. The hospital scene, and the scene where the homeless invade a demolition site, are all-time classics. Look for the legs scene and the two big diggers fighting (one bleeds). This movie gets better each time I see it (which is quite often).'"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x_train_text[2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<b>its label</b>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.0"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "y_train[2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tokenizer\n",
+    "Tokenization is a technique of converting words to numeric values. Here we'll consider 10000 words to be converted to numeric values. This is done because our all the mathematical operations done inside a model require numeric inputs so to deal with that we tokenize our text data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_words = 10000\n",
+    "tokenizer = Tokenizer(num_words = num_words)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 10.8 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "tokenizer.fit_on_texts(data_text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<b>here we can see that each word is assigned a numeric value<b>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 128,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'the': 1,\n",
+       " 'and': 2,\n",
+       " 'a': 3,\n",
+       " 'of': 4,\n",
+       " 'to': 5,\n",
+       " 'is': 6,\n",
+       " 'br': 7,\n",
+       " 'in': 8,\n",
+       " 'it': 9,\n",
+       " 'i': 10,\n",
+       " 'this': 11,\n",
+       " 'that': 12,\n",
+       " 'was': 13,\n",
+       " 'as': 14,\n",
+       " 'for': 15,\n",
+       " 'with': 16,\n",
+       " 'movie': 17,\n",
+       " 'but': 18,\n",
+       " 'film': 19,\n",
+       " 'on': 20,\n",
+       " 'not': 21,\n",
+       " 'you': 22,\n",
+       " 'are': 23,\n",
+       " 'his': 24,\n",
+       " 'have': 25,\n",
+       " 'be': 26,\n",
+       " 'one': 27,\n",
+       " 'he': 28,\n",
+       " 'all': 29,\n",
+       " 'at': 30,\n",
+       " 'by': 31,\n",
+       " 'an': 32,\n",
+       " 'they': 33,\n",
+       " 'so': 34,\n",
+       " 'who': 35,\n",
+       " 'from': 36,\n",
+       " 'like': 37,\n",
+       " 'or': 38,\n",
+       " 'just': 39,\n",
+       " 'her': 40,\n",
+       " 'out': 41,\n",
+       " 'about': 42,\n",
+       " 'if': 43,\n",
+       " \"it's\": 44,\n",
+       " 'has': 45,\n",
+       " 'there': 46,\n",
+       " 'some': 47,\n",
+       " 'what': 48,\n",
+       " 'good': 49,\n",
+       " 'when': 50,\n",
+       " 'more': 51,\n",
+       " 'very': 52,\n",
+       " 'up': 53,\n",
+       " 'no': 54,\n",
+       " 'time': 55,\n",
+       " 'my': 56,\n",
+       " 'even': 57,\n",
+       " 'would': 58,\n",
+       " 'she': 59,\n",
+       " 'which': 60,\n",
+       " 'only': 61,\n",
+       " 'really': 62,\n",
+       " 'see': 63,\n",
+       " 'story': 64,\n",
+       " 'their': 65,\n",
+       " 'had': 66,\n",
+       " 'can': 67,\n",
+       " 'me': 68,\n",
+       " 'well': 69,\n",
+       " 'were': 70,\n",
+       " 'than': 71,\n",
+       " 'much': 72,\n",
+       " 'we': 73,\n",
+       " 'bad': 74,\n",
+       " 'been': 75,\n",
+       " 'get': 76,\n",
+       " 'do': 77,\n",
+       " 'great': 78,\n",
+       " 'other': 79,\n",
+       " 'will': 80,\n",
+       " 'also': 81,\n",
+       " 'into': 82,\n",
+       " 'people': 83,\n",
+       " 'because': 84,\n",
+       " 'how': 85,\n",
+       " 'first': 86,\n",
+       " 'him': 87,\n",
+       " 'most': 88,\n",
+       " \"don't\": 89,\n",
+       " 'made': 90,\n",
+       " 'then': 91,\n",
+       " 'its': 92,\n",
+       " 'them': 93,\n",
+       " 'make': 94,\n",
+       " 'way': 95,\n",
+       " 'too': 96,\n",
+       " 'movies': 97,\n",
+       " 'could': 98,\n",
+       " 'any': 99,\n",
+       " 'after': 100,\n",
+       " 'think': 101,\n",
+       " 'characters': 102,\n",
+       " 'watch': 103,\n",
+       " 'films': 104,\n",
+       " 'two': 105,\n",
+       " 'many': 106,\n",
+       " 'seen': 107,\n",
+       " 'character': 108,\n",
+       " 'being': 109,\n",
+       " 'never': 110,\n",
+       " 'plot': 111,\n",
+       " 'love': 112,\n",
+       " 'acting': 113,\n",
+       " 'life': 114,\n",
+       " 'did': 115,\n",
+       " 'best': 116,\n",
+       " 'where': 117,\n",
+       " 'know': 118,\n",
+       " 'show': 119,\n",
+       " 'little': 120,\n",
+       " 'over': 121,\n",
+       " 'off': 122,\n",
+       " 'ever': 123,\n",
+       " 'does': 124,\n",
+       " 'your': 125,\n",
+       " 'better': 126,\n",
+       " 'end': 127,\n",
+       " 'man': 128,\n",
+       " 'scene': 129,\n",
+       " 'still': 130,\n",
+       " 'say': 131,\n",
+       " 'these': 132,\n",
+       " 'here': 133,\n",
+       " 'scenes': 134,\n",
+       " 'why': 135,\n",
+       " 'while': 136,\n",
+       " 'something': 137,\n",
+       " 'such': 138,\n",
+       " 'go': 139,\n",
+       " 'through': 140,\n",
+       " 'back': 141,\n",
+       " 'should': 142,\n",
+       " 'those': 143,\n",
+       " 'real': 144,\n",
+       " \"i'm\": 145,\n",
+       " 'now': 146,\n",
+       " 'watching': 147,\n",
+       " 'thing': 148,\n",
+       " \"doesn't\": 149,\n",
+       " 'actors': 150,\n",
+       " 'though': 151,\n",
+       " 'funny': 152,\n",
+       " 'years': 153,\n",
+       " \"didn't\": 154,\n",
+       " 'old': 155,\n",
+       " '10': 156,\n",
+       " 'another': 157,\n",
+       " 'work': 158,\n",
+       " 'before': 159,\n",
+       " 'actually': 160,\n",
+       " 'nothing': 161,\n",
+       " 'makes': 162,\n",
+       " 'look': 163,\n",
+       " 'director': 164,\n",
+       " 'find': 165,\n",
+       " 'going': 166,\n",
+       " 'same': 167,\n",
+       " 'new': 168,\n",
+       " 'lot': 169,\n",
+       " 'every': 170,\n",
+       " 'few': 171,\n",
+       " 'again': 172,\n",
+       " 'part': 173,\n",
+       " 'cast': 174,\n",
+       " 'down': 175,\n",
+       " 'us': 176,\n",
+       " 'things': 177,\n",
+       " 'want': 178,\n",
+       " 'quite': 179,\n",
+       " 'pretty': 180,\n",
+       " 'world': 181,\n",
+       " 'horror': 182,\n",
+       " 'around': 183,\n",
+       " 'seems': 184,\n",
+       " \"can't\": 185,\n",
+       " 'young': 186,\n",
+       " 'take': 187,\n",
+       " 'however': 188,\n",
+       " 'got': 189,\n",
+       " 'thought': 190,\n",
+       " 'big': 191,\n",
+       " 'fact': 192,\n",
+       " 'enough': 193,\n",
+       " 'long': 194,\n",
+       " 'both': 195,\n",
+       " \"that's\": 196,\n",
+       " 'give': 197,\n",
+       " \"i've\": 198,\n",
+       " 'own': 199,\n",
+       " 'may': 200,\n",
+       " 'between': 201,\n",
+       " 'comedy': 202,\n",
+       " 'right': 203,\n",
+       " 'series': 204,\n",
+       " 'action': 205,\n",
+       " 'must': 206,\n",
+       " 'music': 207,\n",
+       " 'without': 208,\n",
+       " 'times': 209,\n",
+       " 'saw': 210,\n",
+       " 'always': 211,\n",
+       " 'original': 212,\n",
+       " \"isn't\": 213,\n",
+       " 'role': 214,\n",
+       " 'come': 215,\n",
+       " 'almost': 216,\n",
+       " 'gets': 217,\n",
+       " 'interesting': 218,\n",
+       " 'guy': 219,\n",
+       " 'point': 220,\n",
+       " 'done': 221,\n",
+       " \"there's\": 222,\n",
+       " 'whole': 223,\n",
+       " 'least': 224,\n",
+       " 'far': 225,\n",
+       " 'bit': 226,\n",
+       " 'script': 227,\n",
+       " 'minutes': 228,\n",
+       " 'feel': 229,\n",
+       " '2': 230,\n",
+       " 'anything': 231,\n",
+       " 'making': 232,\n",
+       " 'might': 233,\n",
+       " 'since': 234,\n",
+       " 'am': 235,\n",
+       " 'family': 236,\n",
+       " \"he's\": 237,\n",
+       " 'last': 238,\n",
+       " 'probably': 239,\n",
+       " 'tv': 240,\n",
+       " 'performance': 241,\n",
+       " 'kind': 242,\n",
+       " 'away': 243,\n",
+       " 'yet': 244,\n",
+       " 'fun': 245,\n",
+       " 'worst': 246,\n",
+       " 'sure': 247,\n",
+       " 'rather': 248,\n",
+       " 'hard': 249,\n",
+       " 'anyone': 250,\n",
+       " 'girl': 251,\n",
+       " 'each': 252,\n",
+       " 'played': 253,\n",
+       " 'day': 254,\n",
+       " 'found': 255,\n",
+       " 'looking': 256,\n",
+       " 'woman': 257,\n",
+       " 'screen': 258,\n",
+       " 'although': 259,\n",
+       " 'our': 260,\n",
+       " 'especially': 261,\n",
+       " 'believe': 262,\n",
+       " 'having': 263,\n",
+       " 'trying': 264,\n",
+       " 'course': 265,\n",
+       " 'dvd': 266,\n",
+       " 'everything': 267,\n",
+       " 'set': 268,\n",
+       " 'goes': 269,\n",
+       " 'comes': 270,\n",
+       " 'put': 271,\n",
+       " 'ending': 272,\n",
+       " 'maybe': 273,\n",
+       " 'place': 274,\n",
+       " 'book': 275,\n",
+       " 'shows': 276,\n",
+       " 'three': 277,\n",
+       " 'worth': 278,\n",
+       " 'different': 279,\n",
+       " 'main': 280,\n",
+       " 'once': 281,\n",
+       " 'sense': 282,\n",
+       " 'american': 283,\n",
+       " 'reason': 284,\n",
+       " 'looks': 285,\n",
+       " 'effects': 286,\n",
+       " 'watched': 287,\n",
+       " 'play': 288,\n",
+       " 'true': 289,\n",
+       " 'money': 290,\n",
+       " 'actor': 291,\n",
+       " \"wasn't\": 292,\n",
+       " 'job': 293,\n",
+       " 'together': 294,\n",
+       " 'war': 295,\n",
+       " 'someone': 296,\n",
+       " 'plays': 297,\n",
+       " 'instead': 298,\n",
+       " 'high': 299,\n",
+       " 'during': 300,\n",
+       " 'said': 301,\n",
+       " 'year': 302,\n",
+       " 'half': 303,\n",
+       " 'everyone': 304,\n",
+       " 'later': 305,\n",
+       " 'takes': 306,\n",
+       " '1': 307,\n",
+       " 'seem': 308,\n",
+       " 'audience': 309,\n",
+       " 'special': 310,\n",
+       " 'beautiful': 311,\n",
+       " 'left': 312,\n",
+       " 'himself': 313,\n",
+       " 'seeing': 314,\n",
+       " 'john': 315,\n",
+       " 'night': 316,\n",
+       " 'black': 317,\n",
+       " 'version': 318,\n",
+       " 'shot': 319,\n",
+       " 'excellent': 320,\n",
+       " 'idea': 321,\n",
+       " 'house': 322,\n",
+       " 'mind': 323,\n",
+       " 'star': 324,\n",
+       " 'wife': 325,\n",
+       " 'fan': 326,\n",
+       " 'death': 327,\n",
+       " 'used': 328,\n",
+       " 'else': 329,\n",
+       " 'simply': 330,\n",
+       " 'nice': 331,\n",
+       " 'budget': 332,\n",
+       " 'poor': 333,\n",
+       " 'short': 334,\n",
+       " 'completely': 335,\n",
+       " 'second': 336,\n",
+       " \"you're\": 337,\n",
+       " '3': 338,\n",
+       " 'read': 339,\n",
+       " 'less': 340,\n",
+       " 'along': 341,\n",
+       " 'top': 342,\n",
+       " 'help': 343,\n",
+       " 'home': 344,\n",
+       " 'men': 345,\n",
+       " 'either': 346,\n",
+       " 'line': 347,\n",
+       " 'boring': 348,\n",
+       " 'dead': 349,\n",
+       " 'friends': 350,\n",
+       " 'kids': 351,\n",
+       " 'try': 352,\n",
+       " 'production': 353,\n",
+       " 'enjoy': 354,\n",
+       " 'camera': 355,\n",
+       " 'use': 356,\n",
+       " 'wrong': 357,\n",
+       " 'given': 358,\n",
+       " 'low': 359,\n",
+       " 'classic': 360,\n",
+       " 'father': 361,\n",
+       " 'need': 362,\n",
+       " 'full': 363,\n",
+       " 'stupid': 364,\n",
+       " 'next': 365,\n",
+       " 'until': 366,\n",
+       " 'performances': 367,\n",
+       " 'school': 368,\n",
+       " 'hollywood': 369,\n",
+       " 'rest': 370,\n",
+       " 'truly': 371,\n",
+       " 'awful': 372,\n",
+       " 'video': 373,\n",
+       " 'couple': 374,\n",
+       " 'start': 375,\n",
+       " 'sex': 376,\n",
+       " 'recommend': 377,\n",
+       " 'women': 378,\n",
+       " 'let': 379,\n",
+       " 'tell': 380,\n",
+       " 'terrible': 381,\n",
+       " 'remember': 382,\n",
+       " 'mean': 383,\n",
+       " 'came': 384,\n",
+       " 'getting': 385,\n",
+       " 'understand': 386,\n",
+       " 'perhaps': 387,\n",
+       " 'moments': 388,\n",
+       " 'name': 389,\n",
+       " 'keep': 390,\n",
+       " 'face': 391,\n",
+       " 'itself': 392,\n",
+       " 'wonderful': 393,\n",
+       " 'playing': 394,\n",
+       " 'human': 395,\n",
+       " 'style': 396,\n",
+       " 'small': 397,\n",
+       " 'episode': 398,\n",
+       " 'perfect': 399,\n",
+       " 'others': 400,\n",
+       " 'person': 401,\n",
+       " 'doing': 402,\n",
+       " 'often': 403,\n",
+       " 'early': 404,\n",
+       " 'stars': 405,\n",
+       " 'definitely': 406,\n",
+       " 'written': 407,\n",
+       " 'head': 408,\n",
+       " 'lines': 409,\n",
+       " 'dialogue': 410,\n",
+       " 'gives': 411,\n",
+       " 'piece': 412,\n",
+       " \"couldn't\": 413,\n",
+       " 'went': 414,\n",
+       " 'finally': 415,\n",
+       " 'mother': 416,\n",
+       " 'case': 417,\n",
+       " 'title': 418,\n",
+       " 'absolutely': 419,\n",
+       " 'live': 420,\n",
+       " 'boy': 421,\n",
+       " 'yes': 422,\n",
+       " 'laugh': 423,\n",
+       " 'certainly': 424,\n",
+       " 'liked': 425,\n",
+       " 'become': 426,\n",
+       " 'entertaining': 427,\n",
+       " 'worse': 428,\n",
+       " 'oh': 429,\n",
+       " 'sort': 430,\n",
+       " 'loved': 431,\n",
+       " 'lost': 432,\n",
+       " 'hope': 433,\n",
+       " 'called': 434,\n",
+       " 'picture': 435,\n",
+       " 'felt': 436,\n",
+       " 'overall': 437,\n",
+       " 'entire': 438,\n",
+       " 'mr': 439,\n",
+       " 'several': 440,\n",
+       " 'based': 441,\n",
+       " 'supposed': 442,\n",
+       " 'cinema': 443,\n",
+       " 'friend': 444,\n",
+       " 'guys': 445,\n",
+       " 'sound': 446,\n",
+       " '5': 447,\n",
+       " 'problem': 448,\n",
+       " 'drama': 449,\n",
+       " 'against': 450,\n",
+       " 'waste': 451,\n",
+       " 'white': 452,\n",
+       " 'beginning': 453,\n",
+       " '4': 454,\n",
+       " 'fans': 455,\n",
+       " 'totally': 456,\n",
+       " 'dark': 457,\n",
+       " 'care': 458,\n",
+       " 'direction': 459,\n",
+       " 'humor': 460,\n",
+       " 'wanted': 461,\n",
+       " \"she's\": 462,\n",
+       " 'seemed': 463,\n",
+       " 'under': 464,\n",
+       " 'game': 465,\n",
+       " 'children': 466,\n",
+       " 'despite': 467,\n",
+       " 'lives': 468,\n",
+       " 'lead': 469,\n",
+       " 'guess': 470,\n",
+       " 'example': 471,\n",
+       " 'already': 472,\n",
+       " 'final': 473,\n",
+       " 'throughout': 474,\n",
+       " \"you'll\": 475,\n",
+       " 'evil': 476,\n",
+       " 'turn': 477,\n",
+       " 'becomes': 478,\n",
+       " 'unfortunately': 479,\n",
+       " 'able': 480,\n",
+       " 'quality': 481,\n",
+       " \"i'd\": 482,\n",
+       " 'days': 483,\n",
+       " 'history': 484,\n",
+       " 'fine': 485,\n",
+       " 'side': 486,\n",
+       " 'wants': 487,\n",
+       " 'heart': 488,\n",
+       " 'horrible': 489,\n",
+       " 'writing': 490,\n",
+       " 'amazing': 491,\n",
+       " 'b': 492,\n",
+       " 'flick': 493,\n",
+       " 'killer': 494,\n",
+       " 'run': 495,\n",
+       " 'son': 496,\n",
+       " '\\x96': 497,\n",
+       " 'michael': 498,\n",
+       " 'works': 499,\n",
+       " 'close': 500,\n",
+       " \"they're\": 501,\n",
+       " 'act': 502,\n",
+       " 'art': 503,\n",
+       " 'matter': 504,\n",
+       " 'kill': 505,\n",
+       " 'etc': 506,\n",
+       " 'tries': 507,\n",
+       " \"won't\": 508,\n",
+       " 'past': 509,\n",
+       " 'town': 510,\n",
+       " 'turns': 511,\n",
+       " 'enjoyed': 512,\n",
+       " 'brilliant': 513,\n",
+       " 'gave': 514,\n",
+       " 'behind': 515,\n",
+       " 'parts': 516,\n",
+       " 'stuff': 517,\n",
+       " 'genre': 518,\n",
+       " 'eyes': 519,\n",
+       " 'car': 520,\n",
+       " 'favorite': 521,\n",
+       " 'directed': 522,\n",
+       " 'late': 523,\n",
+       " 'hand': 524,\n",
+       " 'expect': 525,\n",
+       " 'soon': 526,\n",
+       " 'hour': 527,\n",
+       " 'obviously': 528,\n",
+       " 'themselves': 529,\n",
+       " 'sometimes': 530,\n",
+       " 'killed': 531,\n",
+       " 'actress': 532,\n",
+       " 'thinking': 533,\n",
+       " 'child': 534,\n",
+       " 'girls': 535,\n",
+       " 'viewer': 536,\n",
+       " 'starts': 537,\n",
+       " 'city': 538,\n",
+       " 'myself': 539,\n",
+       " 'decent': 540,\n",
+       " 'highly': 541,\n",
+       " 'stop': 542,\n",
+       " 'type': 543,\n",
+       " 'self': 544,\n",
+       " 'god': 545,\n",
+       " 'says': 546,\n",
+       " 'group': 547,\n",
+       " 'anyway': 548,\n",
+       " 'voice': 549,\n",
+       " 'took': 550,\n",
+       " 'known': 551,\n",
+       " 'blood': 552,\n",
+       " 'kid': 553,\n",
+       " 'heard': 554,\n",
+       " 'happens': 555,\n",
+       " 'except': 556,\n",
+       " 'fight': 557,\n",
+       " 'feeling': 558,\n",
+       " 'experience': 559,\n",
+       " 'coming': 560,\n",
+       " 'slow': 561,\n",
+       " 'daughter': 562,\n",
+       " 'writer': 563,\n",
+       " 'stories': 564,\n",
+       " 'moment': 565,\n",
+       " 'leave': 566,\n",
+       " 'told': 567,\n",
+       " 'extremely': 568,\n",
+       " 'score': 569,\n",
+       " 'violence': 570,\n",
+       " 'police': 571,\n",
+       " 'involved': 572,\n",
+       " 'strong': 573,\n",
+       " 'chance': 574,\n",
+       " 'lack': 575,\n",
+       " 'cannot': 576,\n",
+       " 'hit': 577,\n",
+       " 'roles': 578,\n",
+       " 'hilarious': 579,\n",
+       " 's': 580,\n",
+       " 'wonder': 581,\n",
+       " 'happen': 582,\n",
+       " 'particularly': 583,\n",
+       " 'ok': 584,\n",
+       " 'including': 585,\n",
+       " 'living': 586,\n",
+       " 'save': 587,\n",
+       " 'looked': 588,\n",
+       " \"wouldn't\": 589,\n",
+       " 'crap': 590,\n",
+       " 'please': 591,\n",
+       " 'simple': 592,\n",
+       " 'murder': 593,\n",
+       " 'cool': 594,\n",
+       " 'obvious': 595,\n",
+       " 'happened': 596,\n",
+       " 'complete': 597,\n",
+       " 'cut': 598,\n",
+       " 'age': 599,\n",
+       " 'serious': 600,\n",
+       " 'gore': 601,\n",
+       " 'attempt': 602,\n",
+       " 'hell': 603,\n",
+       " 'ago': 604,\n",
+       " 'song': 605,\n",
+       " 'shown': 606,\n",
+       " 'taken': 607,\n",
+       " 'english': 608,\n",
+       " 'james': 609,\n",
+       " 'robert': 610,\n",
+       " 'david': 611,\n",
+       " 'seriously': 612,\n",
+       " 'released': 613,\n",
+       " 'reality': 614,\n",
+       " 'opening': 615,\n",
+       " 'jokes': 616,\n",
+       " 'interest': 617,\n",
+       " 'across': 618,\n",
+       " 'none': 619,\n",
+       " 'hero': 620,\n",
+       " 'today': 621,\n",
+       " 'possible': 622,\n",
+       " 'exactly': 623,\n",
+       " 'alone': 624,\n",
+       " 'sad': 625,\n",
+       " 'brother': 626,\n",
+       " 'number': 627,\n",
+       " 'saying': 628,\n",
+       " 'career': 629,\n",
+       " \"film's\": 630,\n",
+       " 'usually': 631,\n",
+       " 'hours': 632,\n",
+       " 'cinematography': 633,\n",
+       " 'talent': 634,\n",
+       " 'view': 635,\n",
+       " 'yourself': 636,\n",
+       " 'annoying': 637,\n",
+       " 'running': 638,\n",
+       " 'relationship': 639,\n",
+       " 'documentary': 640,\n",
+       " 'wish': 641,\n",
+       " 'order': 642,\n",
+       " 'huge': 643,\n",
+       " 'whose': 644,\n",
+       " 'shots': 645,\n",
+       " 'ridiculous': 646,\n",
+       " 'taking': 647,\n",
+       " 'important': 648,\n",
+       " 'light': 649,\n",
+       " 'body': 650,\n",
+       " 'middle': 651,\n",
+       " 'level': 652,\n",
+       " 'ends': 653,\n",
+       " 'female': 654,\n",
+       " 'started': 655,\n",
+       " 'call': 656,\n",
+       " \"i'll\": 657,\n",
+       " 'husband': 658,\n",
+       " 'four': 659,\n",
+       " 'power': 660,\n",
+       " 'major': 661,\n",
+       " 'word': 662,\n",
+       " 'turned': 663,\n",
+       " 'opinion': 664,\n",
+       " 'change': 665,\n",
+       " 'mostly': 666,\n",
+       " 'usual': 667,\n",
+       " 'scary': 668,\n",
+       " 'silly': 669,\n",
+       " 'rating': 670,\n",
+       " 'beyond': 671,\n",
+       " 'somewhat': 672,\n",
+       " 'ones': 673,\n",
+       " 'happy': 674,\n",
+       " 'words': 675,\n",
+       " 'room': 676,\n",
+       " 'knew': 677,\n",
+       " 'knows': 678,\n",
+       " 'country': 679,\n",
+       " 'disappointed': 680,\n",
+       " 'talking': 681,\n",
+       " 'novel': 682,\n",
+       " 'apparently': 683,\n",
+       " 'non': 684,\n",
+       " 'strange': 685,\n",
+       " 'attention': 686,\n",
+       " 'upon': 687,\n",
+       " 'finds': 688,\n",
+       " 'single': 689,\n",
+       " 'basically': 690,\n",
+       " 'cheap': 691,\n",
+       " 'modern': 692,\n",
+       " 'due': 693,\n",
+       " 'jack': 694,\n",
+       " 'television': 695,\n",
+       " 'musical': 696,\n",
+       " 'problems': 697,\n",
+       " 'miss': 698,\n",
+       " 'episodes': 699,\n",
+       " 'clearly': 700,\n",
+       " 'local': 701,\n",
+       " '7': 702,\n",
+       " 'british': 703,\n",
+       " 'thriller': 704,\n",
+       " 'talk': 705,\n",
+       " 'events': 706,\n",
+       " 'five': 707,\n",
+       " 'sequence': 708,\n",
+       " \"aren't\": 709,\n",
+       " 'class': 710,\n",
+       " 'french': 711,\n",
+       " 'moving': 712,\n",
+       " 'ten': 713,\n",
+       " 'fast': 714,\n",
+       " 'review': 715,\n",
+       " 'earth': 716,\n",
+       " 'tells': 717,\n",
+       " 'predictable': 718,\n",
+       " 'team': 719,\n",
+       " 'songs': 720,\n",
+       " 'comic': 721,\n",
+       " 'straight': 722,\n",
+       " '8': 723,\n",
+       " 'whether': 724,\n",
+       " 'die': 725,\n",
+       " 'add': 726,\n",
+       " 'dialog': 727,\n",
+       " 'entertainment': 728,\n",
+       " 'above': 729,\n",
+       " 'sets': 730,\n",
+       " 'future': 731,\n",
+       " 'enjoyable': 732,\n",
+       " 'appears': 733,\n",
+       " 'near': 734,\n",
+       " 'space': 735,\n",
+       " 'easily': 736,\n",
+       " 'hate': 737,\n",
+       " 'soundtrack': 738,\n",
+       " 'bring': 739,\n",
+       " 'giving': 740,\n",
+       " 'lots': 741,\n",
+       " 'similar': 742,\n",
+       " 'romantic': 743,\n",
+       " 'george': 744,\n",
+       " 'supporting': 745,\n",
+       " 'release': 746,\n",
+       " 'mention': 747,\n",
+       " 'within': 748,\n",
+       " 'filmed': 749,\n",
+       " 'message': 750,\n",
+       " 'sequel': 751,\n",
+       " 'clear': 752,\n",
+       " 'falls': 753,\n",
+       " 'needs': 754,\n",
+       " \"haven't\": 755,\n",
+       " 'dull': 756,\n",
+       " 'suspense': 757,\n",
+       " 'bunch': 758,\n",
+       " 'eye': 759,\n",
+       " 'surprised': 760,\n",
+       " 'showing': 761,\n",
+       " 'tried': 762,\n",
+       " 'sorry': 763,\n",
+       " 'certain': 764,\n",
+       " 'working': 765,\n",
+       " 'easy': 766,\n",
+       " 'ways': 767,\n",
+       " 'theme': 768,\n",
+       " 'theater': 769,\n",
+       " 'named': 770,\n",
+       " 'among': 771,\n",
+       " \"what's\": 772,\n",
+       " 'storyline': 773,\n",
+       " 'monster': 774,\n",
+       " 'king': 775,\n",
+       " 'stay': 776,\n",
+       " 'effort': 777,\n",
+       " 'fall': 778,\n",
+       " 'stand': 779,\n",
+       " 'minute': 780,\n",
+       " 'gone': 781,\n",
+       " 'rock': 782,\n",
+       " 'using': 783,\n",
+       " '9': 784,\n",
+       " 'feature': 785,\n",
+       " 'comments': 786,\n",
+       " 'buy': 787,\n",
+       " \"'\": 788,\n",
+       " 'typical': 789,\n",
+       " 't': 790,\n",
+       " 'editing': 791,\n",
+       " 'sister': 792,\n",
+       " 'avoid': 793,\n",
+       " 'tale': 794,\n",
+       " 'mystery': 795,\n",
+       " 'deal': 796,\n",
+       " 'dr': 797,\n",
+       " 'doubt': 798,\n",
+       " 'fantastic': 799,\n",
+       " 'kept': 800,\n",
+       " 'nearly': 801,\n",
+       " 'feels': 802,\n",
+       " 'okay': 803,\n",
+       " 'subject': 804,\n",
+       " 'viewing': 805,\n",
+       " 'elements': 806,\n",
+       " 'oscar': 807,\n",
+       " 'check': 808,\n",
+       " 'realistic': 809,\n",
+       " 'points': 810,\n",
+       " 'greatest': 811,\n",
+       " 'means': 812,\n",
+       " 'herself': 813,\n",
+       " 'parents': 814,\n",
+       " 'famous': 815,\n",
+       " 'imagine': 816,\n",
+       " 'rent': 817,\n",
+       " 'viewers': 818,\n",
+       " 'richard': 819,\n",
+       " 'crime': 820,\n",
+       " 'form': 821,\n",
+       " 'peter': 822,\n",
+       " 'actual': 823,\n",
+       " 'lady': 824,\n",
+       " 'general': 825,\n",
+       " 'dog': 826,\n",
+       " 'follow': 827,\n",
+       " 'believable': 828,\n",
+       " 'period': 829,\n",
+       " 'red': 830,\n",
+       " 'move': 831,\n",
+       " 'brought': 832,\n",
+       " 'material': 833,\n",
+       " 'forget': 834,\n",
+       " 'somehow': 835,\n",
+       " 'begins': 836,\n",
+       " 're': 837,\n",
+       " 'reviews': 838,\n",
+       " 'animation': 839,\n",
+       " 'paul': 840,\n",
+       " \"you've\": 841,\n",
+       " 'leads': 842,\n",
+       " 'weak': 843,\n",
+       " 'figure': 844,\n",
+       " 'surprise': 845,\n",
+       " 'hear': 846,\n",
+       " 'sit': 847,\n",
+       " 'average': 848,\n",
+       " 'open': 849,\n",
+       " 'sequences': 850,\n",
+       " 'atmosphere': 851,\n",
+       " 'killing': 852,\n",
+       " 'eventually': 853,\n",
+       " 'tom': 854,\n",
+       " 'learn': 855,\n",
+       " 'premise': 856,\n",
+       " '20': 857,\n",
+       " 'wait': 858,\n",
+       " 'sci': 859,\n",
+       " 'deep': 860,\n",
+       " 'fi': 861,\n",
+       " 'expected': 862,\n",
+       " 'whatever': 863,\n",
+       " 'indeed': 864,\n",
+       " 'particular': 865,\n",
+       " 'poorly': 866,\n",
+       " 'note': 867,\n",
+       " 'lame': 868,\n",
+       " 'dance': 869,\n",
+       " 'imdb': 870,\n",
+       " 'situation': 871,\n",
+       " 'shame': 872,\n",
+       " 'third': 873,\n",
+       " 'york': 874,\n",
+       " 'box': 875,\n",
+       " 'truth': 876,\n",
+       " 'decided': 877,\n",
+       " 'free': 878,\n",
+       " 'hot': 879,\n",
+       " \"who's\": 880,\n",
+       " 'difficult': 881,\n",
+       " 'needed': 882,\n",
+       " 'season': 883,\n",
+       " 'acted': 884,\n",
+       " 'leaves': 885,\n",
+       " 'unless': 886,\n",
+       " 'possibly': 887,\n",
+       " 'emotional': 888,\n",
+       " 'romance': 889,\n",
+       " 'gay': 890,\n",
+       " 'sexual': 891,\n",
+       " 'boys': 892,\n",
+       " 'footage': 893,\n",
+       " 'write': 894,\n",
+       " 'western': 895,\n",
+       " 'forced': 896,\n",
+       " 'credits': 897,\n",
+       " 'reading': 898,\n",
+       " 'memorable': 899,\n",
+       " 'became': 900,\n",
+       " 'doctor': 901,\n",
+       " 'otherwise': 902,\n",
+       " 'crew': 903,\n",
+       " 'begin': 904,\n",
+       " 'air': 905,\n",
+       " 'de': 906,\n",
+       " 'question': 907,\n",
+       " 'society': 908,\n",
+       " 'meet': 909,\n",
+       " 'male': 910,\n",
+       " 'meets': 911,\n",
+       " \"let's\": 912,\n",
+       " 'plus': 913,\n",
+       " 'cheesy': 914,\n",
+       " 'hands': 915,\n",
+       " 'superb': 916,\n",
+       " 'screenplay': 917,\n",
+       " 'interested': 918,\n",
+       " 'beauty': 919,\n",
+       " 'street': 920,\n",
+       " 'features': 921,\n",
+       " 'masterpiece': 922,\n",
+       " 'perfectly': 923,\n",
+       " 'whom': 924,\n",
+       " 'laughs': 925,\n",
+       " 'nature': 926,\n",
+       " 'stage': 927,\n",
+       " 'effect': 928,\n",
+       " 'forward': 929,\n",
+       " 'comment': 930,\n",
+       " 'nor': 931,\n",
+       " 'previous': 932,\n",
+       " 'badly': 933,\n",
+       " 'sounds': 934,\n",
+       " 'e': 935,\n",
+       " 'japanese': 936,\n",
+       " 'weird': 937,\n",
+       " 'island': 938,\n",
+       " 'personal': 939,\n",
+       " 'inside': 940,\n",
+       " 'quickly': 941,\n",
+       " 'total': 942,\n",
+       " 'keeps': 943,\n",
+       " 'towards': 944,\n",
+       " 'result': 945,\n",
+       " 'america': 946,\n",
+       " 'battle': 947,\n",
+       " 'crazy': 948,\n",
+       " 'worked': 949,\n",
+       " 'setting': 950,\n",
+       " 'incredibly': 951,\n",
+       " 'background': 952,\n",
+       " 'earlier': 953,\n",
+       " 'mess': 954,\n",
+       " 'cop': 955,\n",
+       " 'writers': 956,\n",
+       " 'fire': 957,\n",
+       " 'copy': 958,\n",
+       " 'dumb': 959,\n",
+       " 'unique': 960,\n",
+       " 'realize': 961,\n",
+       " 'powerful': 962,\n",
+       " 'lee': 963,\n",
+       " 'mark': 964,\n",
+       " 'business': 965,\n",
+       " 'rate': 966,\n",
+       " 'dramatic': 967,\n",
+       " 'older': 968,\n",
+       " 'pay': 969,\n",
+       " 'following': 970,\n",
+       " 'directors': 971,\n",
+       " 'girlfriend': 972,\n",
+       " 'joke': 973,\n",
+       " 'plenty': 974,\n",
+       " 'directing': 975,\n",
+       " 'various': 976,\n",
+       " 'creepy': 977,\n",
+       " 'baby': 978,\n",
+       " 'development': 979,\n",
+       " 'appear': 980,\n",
+       " 'brings': 981,\n",
+       " 'front': 982,\n",
+       " 'ask': 983,\n",
+       " 'dream': 984,\n",
+       " 'water': 985,\n",
+       " 'rich': 986,\n",
+       " 'admit': 987,\n",
+       " 'bill': 988,\n",
+       " 'apart': 989,\n",
+       " 'joe': 990,\n",
+       " 'fairly': 991,\n",
+       " 'political': 992,\n",
+       " 'leading': 993,\n",
+       " 'reasons': 994,\n",
+       " 'portrayed': 995,\n",
+       " 'spent': 996,\n",
+       " 'telling': 997,\n",
+       " 'cover': 998,\n",
+       " 'outside': 999,\n",
+       " 'fighting': 1000,\n",
+       " ...}"
+      ]
+     },
+     "execution_count": 128,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tokenizer.word_index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 129,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "124252"
+      ]
+     },
+     "execution_count": 129,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(tokenizer.word_index)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 130,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_train_tokens = tokenizer.texts_to_sequences(x_train_text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 131,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Homelessness (or Houselessness as George Carlin stated) has been an issue for years but never a plan to help those on the street that were once considered human who did everything from going to school, work, or vote for the matter. Most people think of the homeless as just a lost cause while worrying about things such as racism, the war on Iraq, pressuring kids to succeed, technology, the elections, inflation, or worrying if they\\'ll be next to end up on the streets.<br /><br />But what if you were given a bet to live on the streets for a month without the luxuries you once had from a home, the entertainment sets, a bathroom, pictures on the wall, a computer, and everything you once treasure to see what it\\'s like to be homeless? That is Goddard Bolt\\'s lesson.<br /><br />Mel Brooks (who directs) who stars as Bolt plays a rich man who has everything in the world until deciding to make a bet with a sissy rival (Jeffery Tambor) to see if he can live in the streets for thirty days without the luxuries; if Bolt succeeds, he can do what he wants with a future project of making more buildings. The bet\\'s on where Bolt is thrown on the street with a bracelet on his leg to monitor his every move where he can\\'t step off the sidewalk. He\\'s given the nickname Pepto by a vagrant after it\\'s written on his forehead where Bolt meets other characters including a woman by the name of Molly (Lesley Ann Warren) an ex-dancer who got divorce before losing her home, and her pals Sailor (Howard Morris) and Fumes (Teddy Wilson) who are already used to the streets. They\\'re survivors. Bolt isn\\'t. He\\'s not used to reaching mutual agreements like he once did when being rich where it\\'s fight or flight, kill or be killed.<br /><br />While the love connection between Molly and Bolt wasn\\'t necessary to plot, I found \"Life Stinks\" to be one of Mel Brooks\\' observant films where prior to being a comedy, it shows a tender side compared to his slapstick work such as Blazing Saddles, Young Frankenstein, or Spaceballs for the matter, to show what it\\'s like having something valuable before losing it the next day or on the other hand making a stupid bet like all rich people do when they don\\'t know what to do with their money. Maybe they should give it to the homeless instead of using it like Monopoly money.<br /><br />Or maybe this film will inspire you to help others.'"
+      ]
+     },
+     "execution_count": 131,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x_train_text[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 132,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([  38,   14,  744, 3506,   45,   75,   32, 1771,   15,  153,   18,\n",
+       "        110,    3, 1344,    5,  343,  143,   20,    1,  920,   12,   70,\n",
+       "        281, 1228,  395,   35,  115,  267,   36,  166,    5,  368,  158,\n",
+       "         38, 2058,   15,    1,  504,   88,   83,  101,    4,    1, 4339,\n",
+       "         14,   39,    3,  432, 1148,  136, 8697,   42,  177,  138,   14,\n",
+       "       2791,    1,  295,   20, 5276,  351,    5, 3029, 2310,    1,   38,\n",
+       "       8697,   43, 3611,   26,  365,    5,  127,   53,   20,    1, 2032,\n",
+       "          7,    7,   18,   48,   43,   22,   70,  358,    3, 2343,    5,\n",
+       "        420,   20,    1, 2032,   15,    3, 3346,  208,    1,   22,  281,\n",
+       "         66,   36,    3,  344,    1,  728,  730,    3, 3864, 1320,   20,\n",
+       "          1, 1543,    3, 1293,    2,  267,   22,  281, 2734,    5,   63,\n",
+       "         48,   44,   37,    5,   26, 4339,   12,    6, 2079,    7,    7,\n",
+       "       3425, 2891,   35, 4446,   35,  405,   14,  297,    3,  986,  128,\n",
+       "         35,   45,  267,    8,    1,  181,  366, 6951,    5,   94,    3,\n",
+       "       2343,   16,    3, 7017, 3090,    5,   63,   43,   28,   67,  420,\n",
+       "          8,    1, 2032,   15, 3082,  483,  208,    1,   43, 2802,   28,\n",
+       "         67,   77,   48,   28,  487,   16,    3,  731, 1146,    4,  232,\n",
+       "         51, 4161,    1,   20,  117,    6, 1334,   20,    1,  920,   16,\n",
+       "          3,   20,   24, 4086,    5,   24,  170,  831,  117,   28,  185,\n",
+       "       1562,  122,    1, 7951,  237,  358,    1,   31,    3,  100,   44,\n",
+       "        407,   20,   24, 9597,  117,  911,   79,  102,  585,    3,  257,\n",
+       "         31,    1,  389,    4, 5176, 2137, 4636,   32, 1222, 3303,   35,\n",
+       "        189, 4287,  159, 2320,   40,  344,    2,   40, 8527, 6229, 1955,\n",
+       "       4910,    2, 7720, 2618,   35,   23,  472,  328,    5,    1, 2032,\n",
+       "        501, 4392,  213,  237,   21,  328,    5, 4805, 6768,   37,   28,\n",
+       "        281,  115,   50,  109,  986,  117,   44,  557,   38, 2574,  505,\n",
+       "         38,   26,  531,    7,    7,  136,    1,  112, 1906,  201, 5176,\n",
+       "          2,  292, 1731,    5,  111,   10,  255,  114, 4541,    5,   26,\n",
+       "         27,    4, 3425,  104,  117, 2557,    5,  109,    3,  202,    9,\n",
+       "        276,    3, 4317,  486, 1107,    5,   24, 2347,  158,  138,   14,\n",
+       "       8161,  186, 3889,   38,   15,    1,  504,    5,  119,   48,   44,\n",
+       "         37,  263,  137, 4737,  159, 2320,    9,    1,  365,  254,   38,\n",
+       "         20,    1,   79,  524,  232,    3,  364, 2343,   37,   29,  986,\n",
+       "         83,   77,   50,   33,   89,  118,   48,    5,   77,   16,   65,\n",
+       "        290,  273,   33,  142,  197,    9,    5,    1, 4339,  298,    4,\n",
+       "        783,    9,   37,  290,    7,    7,   38,  273,   11,   19,   80,\n",
+       "       5541,   22,    5,  343,  400])"
+      ]
+     },
+     "execution_count": 132,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.array(x_train_tokens[1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 133,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_test_tokens = tokenizer.texts_to_sequences(x_test_text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Padding and truncating the data\n",
+    "\n",
+    "The problem now is that all the sentences that we have have has different lenghts  So we need to make sure that the data must have same length "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 134,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_tokens = [len(tokens) for tokens in x_train_tokens + x_test_tokens]\n",
+    "num_tokens = np.array(num_tokens)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 135,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "221.27716"
+      ]
+     },
+     "execution_count": 135,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Average number of words in a sequence is \n",
+    "np.mean(num_tokens)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 136,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2209"
+      ]
+     },
+     "execution_count": 136,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# max number of words is\n",
+    "np.max(num_tokens)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 137,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "544\n"
+     ]
+    }
+   ],
+   "source": [
+    "# The max number of tokens we will allow is set to the average plus 2 standard deviations\n",
+    "max_tokens = np.mean(num_tokens)+ 2 * np.std(num_tokens)\n",
+    "\n",
+    "#Converting the value to int\n",
+    "max_tokens = int(max_tokens)\n",
+    "print(max_tokens)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 138,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.9453"
+      ]
+     },
+     "execution_count": 138,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# How many are shorter than the limit?\n",
+    "np.sum(num_tokens < max_tokens) / len(num_tokens)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What a padding will do is , if the length of the string is less than the desired constant\n",
+    "length of string it gonna fill it up with zeros from the start(if pad = 'pre') or from the end\n",
+    "Now why 'pre' here, cause in this model we've set that the model will know that a text is starting\n",
+    "when the first state is zero so by padding from the start the model will not move to the next layer \n",
+    "and will continue to change the state to the first state since there are zeros all along till \n",
+    "the sentence comes\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 139,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pad = 'pre'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    " What if a text is longer than the required length: then we gonna truncate the text so that it comes \n",
+    " within our range, but there's an issue there. When we are truncating there's a change that we are \n",
+    " losing some important features or say information which is a 'COMPROMISE' that we have to make."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 140,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_train_pad = pad_sequences(x_train_tokens, maxlen = max_tokens, padding= pad, truncating = pad)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 141,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[   0,    0,    0, ...,   12,    9,  213],\n",
+       "       [   0,    0,    0, ...,    5,  343,  400],\n",
+       "       [   0,    0,    0, ...,    6,  179,  403],\n",
+       "       ...,\n",
+       "       [   0,    0,    0, ...,   17,   96,   74],\n",
+       "       [   0,    0,    0, ...,  260, 1219,  793],\n",
+       "       [   0,    0,    0, ...,   11,    6, 1377]])"
+      ]
+     },
+     "execution_count": 141,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x_train_pad"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 142,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_test_pad = pad_sequences(x_test_tokens, maxlen=max_tokens , padding = pad, truncating = pad)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tokenizer inverse map"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We also need a function that will convert our tokenized words back to original. (numbers -> words)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 143,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "idx = tokenizer.word_index\n",
+    "inverse_map = dict(zip(idx.values(), idx.keys()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 144,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Helper function for converting a list of tokends back to a string of words\n",
+    "def tokens_to_string(tokens):\n",
+    "    # Map from tokens back to the words:\n",
+    "    words = [inverse_map[token] for token in tokens if token != 0]\n",
+    "    \n",
+    "    #Concatenate all the words\n",
+    "    text = \" \".join(words)\n",
+    "    return text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 145,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Homelessness (or Houselessness as George Carlin stated) has been an issue for years but never a plan to help those on the street that were once considered human who did everything from going to school, work, or vote for the matter. Most people think of the homeless as just a lost cause while worrying about things such as racism, the war on Iraq, pressuring kids to succeed, technology, the elections, inflation, or worrying if they\\'ll be next to end up on the streets.<br /><br />But what if you were given a bet to live on the streets for a month without the luxuries you once had from a home, the entertainment sets, a bathroom, pictures on the wall, a computer, and everything you once treasure to see what it\\'s like to be homeless? That is Goddard Bolt\\'s lesson.<br /><br />Mel Brooks (who directs) who stars as Bolt plays a rich man who has everything in the world until deciding to make a bet with a sissy rival (Jeffery Tambor) to see if he can live in the streets for thirty days without the luxuries; if Bolt succeeds, he can do what he wants with a future project of making more buildings. The bet\\'s on where Bolt is thrown on the street with a bracelet on his leg to monitor his every move where he can\\'t step off the sidewalk. He\\'s given the nickname Pepto by a vagrant after it\\'s written on his forehead where Bolt meets other characters including a woman by the name of Molly (Lesley Ann Warren) an ex-dancer who got divorce before losing her home, and her pals Sailor (Howard Morris) and Fumes (Teddy Wilson) who are already used to the streets. They\\'re survivors. Bolt isn\\'t. He\\'s not used to reaching mutual agreements like he once did when being rich where it\\'s fight or flight, kill or be killed.<br /><br />While the love connection between Molly and Bolt wasn\\'t necessary to plot, I found \"Life Stinks\" to be one of Mel Brooks\\' observant films where prior to being a comedy, it shows a tender side compared to his slapstick work such as Blazing Saddles, Young Frankenstein, or Spaceballs for the matter, to show what it\\'s like having something valuable before losing it the next day or on the other hand making a stupid bet like all rich people do when they don\\'t know what to do with their money. Maybe they should give it to the homeless instead of using it like Monopoly money.<br /><br />Or maybe this film will inspire you to help others.'"
+      ]
+     },
+     "execution_count": 145,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Lets see how well it converts \n",
+    "x_train_text[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 146,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"or as george stated has been an issue for years but never a plan to help those on the street that were once considered human who did everything from going to school work or vote for the matter most people think of the homeless as just a lost cause while worrying about things such as racism the war on iraq kids to succeed technology the or worrying if they'll be next to end up on the streets br br but what if you were given a bet to live on the streets for a month without the you once had from a home the entertainment sets a bathroom pictures on the wall a computer and everything you once treasure to see what it's like to be homeless that is lesson br br mel brooks who directs who stars as plays a rich man who has everything in the world until deciding to make a bet with a sissy rival to see if he can live in the streets for thirty days without the if succeeds he can do what he wants with a future project of making more buildings the on where is thrown on the street with a on his leg to his every move where he can't step off the sidewalk he's given the by a after it's written on his forehead where meets other characters including a woman by the name of molly ann warren an ex dancer who got divorce before losing her home and her pals sailor howard morris and teddy wilson who are already used to the streets they're survivors isn't he's not used to reaching mutual like he once did when being rich where it's fight or flight kill or be killed br br while the love connection between molly and wasn't necessary to plot i found life stinks to be one of mel films where prior to being a comedy it shows a tender side compared to his slapstick work such as blazing young frankenstein or for the matter to show what it's like having something valuable before losing it the next day or on the other hand making a stupid bet like all rich people do when they don't know what to do with their money maybe they should give it to the homeless instead of using it like money br br or maybe this film will inspire you to help others\""
+      ]
+     },
+     "execution_count": 146,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tokens_to_string(x_train_tokens[1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Defining the Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 147,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = Sequential()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The first layer in the RNN is called Embedding layer which converts \n",
+    "each integer-token into a vector value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 148,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "embedding_size = 8"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 149,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.add(Embedding(input_dim = num_words, output_dim = embedding_size, input_length = max_tokens, \n",
+    "                    name = 'layer_embedding'))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Adding the first recurrent layer: \n",
+    "Gated Recurrent Unit \n",
+    "GRU and LSTM are kinda similar in performace on most datasets but the structure of LSTM is quite \n",
+    "complex as compared to GRU where GRU is simpler\n",
+    "Here we want an output dimensionality of 16"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 150,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.add(GRU(16, return_sequences=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-10T11:30:59.703103Z",
+     "start_time": "2019-10-10T11:30:59.697111Z"
+    }
+   },
+   "source": [
+    "This is the second GRU with 8 output units. Ths will be followed by another GRU \n",
+    "so it must also reutrn sequences"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.add(GRU(8, return_sequences = True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    " Now we have the third and the final GRU with 4 output units. This will be followed by a dense layer\n",
+    " so it should only give the final output of the GRU and not a whole sequence of outputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 152,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.add(GRU(4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Adding a fully connected layer which computes a value between 0.0 and 1.0 that will be\n",
+    "used as the classification output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 153,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.add(Dense(1, activation='sigmoid'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 154,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimizer = Adam(lr=1e-3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 155,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.compile(loss ='binary_crossentropy', optimizer =  optimizer, metrics = ['accuracy'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 157,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "_________________________________________________________________\n",
+      "Layer (type)                 Output Shape              Param #   \n",
+      "=================================================================\n",
+      "layer_embedding (Embedding)  (None, 544, 8)            80000     \n",
+      "_________________________________________________________________\n",
+      "gru_25 (GRU)                 (None, 544, 16)           1200      \n",
+      "_________________________________________________________________\n",
+      "gru_26 (GRU)                 (None, 544, 8)            600       \n",
+      "_________________________________________________________________\n",
+      "gru_27 (GRU)                 (None, 4)                 156       \n",
+      "_________________________________________________________________\n",
+      "dense_2 (Dense)              (None, 1)                 5         \n",
+      "=================================================================\n",
+      "Total params: 81,961\n",
+      "Trainable params: 81,961\n",
+      "Non-trainable params: 0\n",
+      "_________________________________________________________________\n"
+     ]
+    }
+   ],
+   "source": [
+    "model.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Training the model with our processed data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 160,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train on 23750 samples, validate on 1250 samples\n",
+      "Epoch 1/3\n",
+      "23750/23750 [==============================] - 206s 9ms/step - loss: 0.3176 - acc: 0.8717 - val_loss: 0.5056 - val_acc: 0.7704\n",
+      "Epoch 2/3\n",
+      "23750/23750 [==============================] - 204s 9ms/step - loss: 0.2219 - acc: 0.9184 - val_loss: 0.5049 - val_acc: 0.8016\n",
+      "Epoch 3/3\n",
+      "23750/23750 [==============================] - 200s 8ms/step - loss: 0.1733 - acc: 0.9417 - val_loss: 0.3327 - val_acc: 0.8712\n",
+      "Wall time: 10min 9s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<tensorflow.python.keras.callbacks.History at 0x1e0310d58d0>"
+      ]
+     },
+     "execution_count": 160,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "model.fit(x_train_pad, y_train, validation_split = 0.05, epochs = 3, batch_size = 64)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 161,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "25000/25000 [==============================] - 73s 3ms/step\n",
+      "Wall time: 1min 13s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "result = model.evaluate(x_test_pad, y_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 163,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy : 86.78%\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Accuracy : {0:.2%}\".format(result[1]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 166,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Examples of mis-classified text\n",
+    "\n",
+    "y_pred = model.predict(x = x_test_pad[0:1000])\n",
+    "y_pred = y_pred.T[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 168,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cls_pred= np.array([1.0 if p>0.5 else 0.0 for p in y_pred])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 169,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cls_true = np.array(y_test[0:1000])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 176,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "incorrect = np.where(cls_pred != cls_true)\n",
+    "incorrect = incorrect[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 178,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "125"
+      ]
+     },
+     "execution_count": 178,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(incorrect)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 179,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "7"
+      ]
+     },
+     "execution_count": 179,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "idx = incorrect[0]\n",
+    "idx"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 180,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"I felt this film did have many good qualities. The cinematography was certainly different exposing the stage aspect of the set and story. The original characters as actors was certainly an achievement and I felt most played quite convincingly, of course they are playing themselves, but definitely unique. The cultural aspects may leave many disappointed as a familiarity with the Chinese and Oriental culture will answer a lot of questions regarding parent/child relationships and the stigma that goes with any drug use. I found the Jia Hongsheng story interesting. On a down note, the story is in Beijing and some of the fashion and music reek of early 90s even though this was made in 2001, so it's really cheesy sometimes (the Beatles crap, etc). Whatever, not a top ten or twenty but if it's on the television, check it out.\""
+      ]
+     },
+     "execution_count": 180,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "text = x_test_text[idx]\n",
+    "text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 185,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.34652925"
+      ]
+     },
+     "execution_count": 185,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#what model said\n",
+    "y_pred[idx]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 186,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.0"
+      ]
+     },
+     "execution_count": 186,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#What it actually is\n",
+    "cls_true[idx]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Testing our model with our own reviews"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    " Now lets see how well our model performs on our own data\n",
+    "you can edit and try it on your own"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 236,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text1 = \"This is a great movie! I really like it because it was so good you know!\"\n",
+    "text2 = \"Good one, really this is how you make a movie. But the sad part is the hero died in the end\"\n",
+    "text3 = \"Worst thing that i've ever seen in my life\"\n",
+    "text4 = \"You call that acting? It was pathetic\"\n",
+    "text5 = \"This movie is so bad man. Can I get my money back??\"\n",
+    "text6 = \"I really like the way they played their roles. I love the story and the climax\"\n",
+    "text7 = \" extremely  bad acting\"\n",
+    "text8 = \"I really hate this movie, it sucks\"\n",
+    "\n",
+    "texts = [text1,text2,text3,text4,text5,text6,text7,text8]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 237,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert the text to integer tokens because that is what our machine demands\n",
+    "tokens = tokenizer.texts_to_sequences(texts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 238,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Padding out input so that it gonna be of the same length\n",
+    "tokens_pad = pad_sequences(tokens, maxlen=max_tokens, padding = pad, truncating= pad)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 239,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(8, 544)"
+      ]
+     },
+     "execution_count": 239,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tokens_pad.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 240,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_out = model.predict(tokens_pad)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 255,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[0.9501376 ]\n",
+      " [0.53903544]\n",
+      " [0.17056009]\n",
+      " [0.71476394]\n",
+      " [0.41013265]\n",
+      " [0.94253695]\n",
+      " [0.3093451 ]\n",
+      " [0.48402002]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(model_out)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 256,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "POSITIVE\n",
+      "POSITIVE\n",
+      "NEGATIVE\n",
+      "POSITIVE\n",
+      "NEGATIVE\n",
+      "POSITIVE\n",
+      "NEGATIVE\n",
+      "NEGATIVE\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Now lets make it human friendly\n",
+    "for i in model_out:\n",
+    "    if i > 0.5:\n",
+    "        print(\"POSITIVE\")\n",
+    "    else:\n",
+    "        print(\"NEGATIVE\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 257,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Lets analyse the model\n",
+    "\n",
+    "layer_embedding = model.get_layer('layer_embedding')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 259,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weights_embedding = layer_embedding.get_weights()[0]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 262,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(10000, 8)"
+      ]
+     },
+     "execution_count": 262,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "weights_embedding.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 267,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "49"
+      ]
+     },
+     "execution_count": 267,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Lets us get the integer-token for the word 'good', which is just an index into the vocabulary\n",
+    "token_good = tokenizer.word_index['good']\n",
+    "token_good"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 268,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2679"
+      ]
+     },
+     "execution_count": 268,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Lets see for another word\n",
+    "token_suck = tokenizer.word_index['suck']\n",
+    "token_suck"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 271,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([-0.06454835, -0.02658044, -0.03438243,  0.06982238, -0.0149335 ,\n",
+       "        0.07477991, -0.05760748, -0.00995041], dtype=float32)"
+      ]
+     },
+     "execution_count": 271,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Now lets see the embedding vectors\n",
+    "weights_embedding[token_good]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 272,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 0.03425425,  0.04777166,  0.04658137, -0.03020082,  0.0352446 ,\n",
+       "       -0.03772571,  0.09680279,  0.09218275], dtype=float32)"
+      ]
+     },
+     "execution_count": 272,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "weights_embedding[token_suck]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Description

Added an Text sentiment classification tutorial using Gated Recurrent Networks on a movie review dataset having positive and negative sentiment.

## Related Issue

https://github.com/catalyst-team/catalyst/issues/426

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [CODE_OF_CONDUCT](../CODE_OF_CONDUCT.md) document.
- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] I have checked the code-style using `make check-style`.
- [ ] I have written the docstring in Google format for all the method and classes that I used.
- [ ] I have checked the docs using `make check-docs`.