### PR TITLE
Migration from tensorboardX to PyTorch native Tensorboard, issue #435

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pip install catalyst[contrib] # installs DL+contrib based catalyst
 pip install catalyst[all] # installs everything. Very convenient to deploy on a new server
 ```
 
-Catalyst is compatible with: Python 3.6+. PyTorch 0.4.1+.
+Catalyst is compatible with: Python 3.6+. PyTorch 1.2.0+.
 
 #### Docs and examples
 - Detailed [classification tutorial](./examples/notebooks/classification-tutorial.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/catalyst-team/catalyst/blob/master/examples/notebooks/classification-tutorial.ipynb)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pip install catalyst[contrib] # installs DL+contrib based catalyst
 pip install catalyst[all] # installs everything. Very convenient to deploy on a new server
 ```
 
-Catalyst is compatible with: Python 3.6+. PyTorch 1.2.0+.
+Catalyst is compatible with: Python 3.6+. PyTorch 0.4.1+.
 
 #### Docs and examples
 - Detailed [classification tutorial](./examples/notebooks/classification-tutorial.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/catalyst-team/catalyst/blob/master/examples/notebooks/classification-tutorial.ipynb)

--- a/catalyst/contrib/scripts/project_embeddings.py
+++ b/catalyst/contrib/scripts/project_embeddings.py
@@ -6,7 +6,13 @@ import cv2
 import numpy as np
 import pandas as pd
 import torch
-from torch.utils.tensorboard import SummaryWriter
+
+# Native tensorboard support from 1.2.0 version of PyTorch
+from packaging import version
+if version.parse(torch.__version__) < version.parse("1.2.0"):
+    from tensorboardX import SummaryWriter
+else:
+    from torch.utils.tensorboard import SummaryWriter
 
 
 def build_args(parser):

--- a/catalyst/contrib/scripts/project_embeddings.py
+++ b/catalyst/contrib/scripts/project_embeddings.py
@@ -6,7 +6,7 @@ import cv2
 import numpy as np
 import pandas as pd
 import torch
-from tensorboardX import SummaryWriter
+from torch.utils.tensorboard import SummaryWriter
 
 
 def build_args(parser):

--- a/catalyst/contrib/scripts/project_embeddings.py
+++ b/catalyst/contrib/scripts/project_embeddings.py
@@ -6,13 +6,7 @@ import cv2
 import numpy as np
 import pandas as pd
 import torch
-
-# Native tensorboard support from 1.2.0 version of PyTorch
-from packaging import version
-if version.parse(torch.__version__) < version.parse("1.2.0"):
-    from tensorboardX import SummaryWriter
-else:
-    from torch.utils.tensorboard import SummaryWriter
+from catalyst.utils.tensorboard import SummaryWriter
 
 
 def build_args(parser):

--- a/catalyst/dl/callbacks/logging.py
+++ b/catalyst/dl/callbacks/logging.py
@@ -3,12 +3,16 @@ import os
 import sys
 import logging
 from tqdm import tqdm
-
-from torch.utils.tensorboard import SummaryWriter
-
 from catalyst.dl.core import Callback, RunnerState, CallbackOrder
 from catalyst.dl.utils.formatters import TxtMetricsFormatter
 from catalyst.dl import utils
+# Native tensorboard support from 1.2.0 version of PyTorch
+from torch import __version__ as torch_version
+from packaging import version
+if version.parse(torch_version) < version.parse("1.2.0"):
+    from tensorboardX import SummaryWriter
+else:
+    from torch.utils.tensorboard import SummaryWriter
 
 
 class VerboseLogger(Callback):

--- a/catalyst/dl/callbacks/logging.py
+++ b/catalyst/dl/callbacks/logging.py
@@ -6,13 +6,7 @@ from tqdm import tqdm
 from catalyst.dl.core import Callback, RunnerState, CallbackOrder
 from catalyst.dl.utils.formatters import TxtMetricsFormatter
 from catalyst.dl import utils
-# Native tensorboard support from 1.2.0 version of PyTorch
-from torch import __version__ as torch_version
-from packaging import version
-if version.parse(torch_version) < version.parse("1.2.0"):
-    from tensorboardX import SummaryWriter
-else:
-    from torch.utils.tensorboard import SummaryWriter
+from catalyst.utils.tensorboard import SummaryWriter
 
 
 class VerboseLogger(Callback):

--- a/catalyst/dl/callbacks/logging.py
+++ b/catalyst/dl/callbacks/logging.py
@@ -4,7 +4,7 @@ import sys
 import logging
 from tqdm import tqdm
 
-from tensorboardX import SummaryWriter
+from torch.utils.tensorboard import SummaryWriter
 
 from catalyst.dl.core import Callback, RunnerState, CallbackOrder
 from catalyst.dl.utils.formatters import TxtMetricsFormatter

--- a/catalyst/rl/core/sampler.py
+++ b/catalyst/rl/core/sampler.py
@@ -17,8 +17,6 @@ import logging  # noqa E402
 import torch  # noqa E402
 torch.set_num_threads(1)
 
-from torch.utils.tensorboard import SummaryWriter  # noqa E402
-
 from catalyst.utils.seed import set_global_seed, Seeder  # noqa E402
 from catalyst import utils  # noqa E402
 from .trajectory_sampler import TrajectorySampler  # noqa E402
@@ -26,6 +24,13 @@ from .exploration import ExplorationHandler  # noqa E402
 from .environment import EnvironmentSpec  # noqa E402
 from .db import DBSpec  # noqa E402
 from .agent import ActorSpec, CriticSpec  # noqa E402
+# Native tensorboard support from 1.2.0 version of PyTorch
+from packaging import version # noqa E402
+if version.parse(torch.__version__) < version.parse("1.2.0"):
+    from tensorboardX import SummaryWriter
+else:
+    from torch.utils.tensorboard import SummaryWriter
+
 
 logger = logging.getLogger(__name__)
 

--- a/catalyst/rl/core/sampler.py
+++ b/catalyst/rl/core/sampler.py
@@ -24,12 +24,7 @@ from .exploration import ExplorationHandler  # noqa E402
 from .environment import EnvironmentSpec  # noqa E402
 from .db import DBSpec  # noqa E402
 from .agent import ActorSpec, CriticSpec  # noqa E402
-# Native tensorboard support from 1.2.0 version of PyTorch
-from packaging import version # noqa E402
-if version.parse(torch.__version__) < version.parse("1.2.0"):
-    from tensorboardX import SummaryWriter
-else:
-    from torch.utils.tensorboard import SummaryWriter
+from catalyst.utils.tensorboard import SummaryWriter  # noqa E402
 
 
 logger = logging.getLogger(__name__)

--- a/catalyst/rl/core/sampler.py
+++ b/catalyst/rl/core/sampler.py
@@ -17,7 +17,7 @@ import logging  # noqa E402
 import torch  # noqa E402
 torch.set_num_threads(1)
 
-from tensorboardX import SummaryWriter  # noqa E402
+from torch.utils.tensorboard import SummaryWriter  # noqa E402
 
 from catalyst.utils.seed import set_global_seed, Seeder  # noqa E402
 from catalyst import utils  # noqa E402

--- a/catalyst/rl/core/trainer.py
+++ b/catalyst/rl/core/trainer.py
@@ -9,7 +9,7 @@ import numpy as np
 import logging
 
 from torch.utils.data import DataLoader
-from tensorboardX import SummaryWriter
+from torch.utils.tensorboard import SummaryWriter
 
 from catalyst.utils.seed import set_global_seed, Seeder
 from catalyst import utils

--- a/catalyst/rl/core/trainer.py
+++ b/catalyst/rl/core/trainer.py
@@ -9,13 +9,19 @@ import numpy as np
 import logging
 
 from torch.utils.data import DataLoader
-from torch.utils.tensorboard import SummaryWriter
-
 from catalyst.utils.seed import set_global_seed, Seeder
 from catalyst import utils
 from .db import DBSpec
 from .environment import EnvironmentSpec
 from .algorithm import AlgorithmSpec
+# Native tensorboard support from 1.2.0 version of PyTorch
+from torch import __version__ as torch_version
+from packaging import version
+if version.parse(torch_version) < version.parse("1.2.0"):
+    from tensorboardX import SummaryWriter
+else:
+    from torch.utils.tensorboard import SummaryWriter
+
 
 logger = logging.getLogger(__name__)
 

--- a/catalyst/rl/core/trainer.py
+++ b/catalyst/rl/core/trainer.py
@@ -14,13 +14,7 @@ from catalyst import utils
 from .db import DBSpec
 from .environment import EnvironmentSpec
 from .algorithm import AlgorithmSpec
-# Native tensorboard support from 1.2.0 version of PyTorch
-from torch import __version__ as torch_version
-from packaging import version
-if version.parse(torch_version) < version.parse("1.2.0"):
-    from tensorboardX import SummaryWriter
-else:
-    from torch.utils.tensorboard import SummaryWriter
+from catalyst.utils.tensorboard import SummaryWriter
 
 
 logger = logging.getLogger(__name__)

--- a/catalyst/utils/config.py
+++ b/catalyst/utils/config.py
@@ -13,9 +13,15 @@ from typing import List, Any, Dict, Union
 
 import safitty
 import yaml
-from torch.utils.tensorboard import SummaryWriter
 
 from catalyst import utils
+# Native tensorboard support from 1.2.0 version of PyTorch
+from torch import __version__ as torch_version
+from packaging import version
+if version.parse(torch_version) < version.parse("1.2.0"):
+    from tensorboardX import SummaryWriter
+else:
+    from torch.utils.tensorboard import SummaryWriter
 
 LOG = getLogger(__name__)
 

--- a/catalyst/utils/config.py
+++ b/catalyst/utils/config.py
@@ -15,13 +15,7 @@ import safitty
 import yaml
 
 from catalyst import utils
-# Native tensorboard support from 1.2.0 version of PyTorch
-from torch import __version__ as torch_version
-from packaging import version
-if version.parse(torch_version) < version.parse("1.2.0"):
-    from tensorboardX import SummaryWriter
-else:
-    from torch.utils.tensorboard import SummaryWriter
+from catalyst.utils.tensorboard import SummaryWriter
 
 LOG = getLogger(__name__)
 

--- a/catalyst/utils/config.py
+++ b/catalyst/utils/config.py
@@ -13,7 +13,7 @@ from typing import List, Any, Dict, Union
 
 import safitty
 import yaml
-from tensorboardX import SummaryWriter
+from torch.utils.tensorboard import SummaryWriter
 
 from catalyst import utils
 

--- a/catalyst/utils/tensorboard.py
+++ b/catalyst/utils/tensorboard.py
@@ -6,7 +6,7 @@ from typing import BinaryIO, Union, Optional
 
 import cv2
 import numpy as np
-from tensorboardX.proto.event_pb2 import Event
+from tensorboard.compat.proto.event_pb2 import Event
 
 import os
 if os.environ.get("CRC32C_SW_MODE", None) is None:

--- a/catalyst/utils/tensorboard.py
+++ b/catalyst/utils/tensorboard.py
@@ -6,12 +6,19 @@ from typing import BinaryIO, Union, Optional
 
 import cv2
 import numpy as np
-from tensorboard.compat.proto.event_pb2 import Event
-
 import os
+
 if os.environ.get("CRC32C_SW_MODE", None) is None:
     os.environ["CRC32C_SW_MODE"] = "auto"
 from crc32c import crc32 as crc32c  # noqa: E402
+
+# Native tensorboard support from 1.2.0 version of PyTorch
+from torch import __version__ as torch_version  # noqa: E402
+from packaging import version  # noqa: E402
+if version.parse(torch_version) < version.parse("1.2.0"):
+    from tensorboardX.proto.event_pb2 import Event
+else:
+    from tensorboard.compat.proto.event_pb2 import Event
 
 
 def _u32(x):

--- a/catalyst/utils/tensorboard.py
+++ b/catalyst/utils/tensorboard.py
@@ -16,6 +16,12 @@ from crc32c import crc32 as crc32c  # noqa: E402
 from torch import __version__ as torch_version  # noqa: E402
 from packaging import version  # noqa: E402
 if version.parse(torch_version) < version.parse("1.2.0"):
+    from tensorboardX import SummaryWriter as tensorboardX_SummaryWriter
+    SummaryWriter = tensorboardX_SummaryWriter
+else:
+    from torch.utils.tensorboard import SummaryWriter as torch_SummaryWriter
+    SummaryWriter = torch_SummaryWriter
+if version.parse(torch_version) < version.parse("1.2.0"):
     from tensorboardX.proto.event_pb2 import Event
 else:
     from tensorboard.compat.proto.event_pb2 import Event

--- a/examples/mnist_gan/callbacks.py
+++ b/examples/mnist_gan/callbacks.py
@@ -2,7 +2,7 @@ import torch
 import torchvision.utils
 from catalyst.dl import registry
 from catalyst.dl.core import Callback, CallbackOrder, RunnerState
-from tensorboardX import SummaryWriter
+from torch.utils.tensorboard import SummaryWriter
 
 
 @registry.Callback

--- a/examples/mnist_gan/callbacks.py
+++ b/examples/mnist_gan/callbacks.py
@@ -2,7 +2,13 @@ import torch
 import torchvision.utils
 from catalyst.dl import registry
 from catalyst.dl.core import Callback, CallbackOrder, RunnerState
-from torch.utils.tensorboard import SummaryWriter
+
+# Native tensorboard support from 1.2.0 version of PyTorch
+from packaging import version
+if version.parse(torch.__version__) < version.parse("1.2.0"):
+    from tensorboardX import SummaryWriter
+else:
+    from torch.utils.tensorboard import SummaryWriter
 
 
 @registry.Callback

--- a/examples/mnist_gan/callbacks.py
+++ b/examples/mnist_gan/callbacks.py
@@ -2,13 +2,7 @@ import torch
 import torchvision.utils
 from catalyst.dl import registry
 from catalyst.dl.core import Callback, CallbackOrder, RunnerState
-
-# Native tensorboard support from 1.2.0 version of PyTorch
-from packaging import version
-if version.parse(torch.__version__) < version.parse("1.2.0"):
-    from tensorboardX import SummaryWriter
-else:
-    from torch.utils.tensorboard import SummaryWriter
+from catalyst.utils.tensorboard import SummaryWriter
 
 
 @registry.Callback

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,13 +1,13 @@
 # Framework must-haves
 numpy>=1.16.4
-torch>=0.4.1
+torch>=1.2.0
 torchvision>=0.2.1
 imageio
 opencv-python
 scikit-image>=0.14.2
 tqdm>=4.29.1
 PyYAML
-tensorboardX>=1.8
+tensorboard
 plotly>=4.1.0
 safitty>=1.2.3
 crc32c>=1.7

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 # Framework must-haves
 numpy>=1.16.4
-torch>=1.2.0
+torch>=0.4.1
 torchvision>=0.2.1
 imageio
 opencv-python
@@ -8,6 +8,7 @@ scikit-image>=0.14.2
 tqdm>=4.29.1
 PyYAML
 tensorboard
+tensorboardX
 plotly>=4.1.0
 safitty>=1.2.3
 crc32c>=1.7


### PR DESCRIPTION
Migration from tensorboardX to PyTorch native Tensorboard.

## Description

Changes:
1. Requirements updated, minimum PyTorch version is 1.2.0 now, tensorboardX -> tensorboard.
2. All tensorboardX package references have been changed to torch.utils.tensorboard.
3. Important change in catalyst/utils/tensorboard.py: Event imported from tensorboard.compat.proto.event_b2, not from tensorboardX.proto.eventb2.

## Related Issue

https://github.com/catalyst-team/catalyst/issues/435

## Type of Change

- [X] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] I have read the [CODE_OF_CONDUCT](../CODE_OF_CONDUCT.md) document.
- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [X] I have checked the code-style using `make check-style`.
- [ ] I have written the docstring in Google format for all the method and classes that I used.
- [ ] I have checked the docs using `make check-docs`.