### PR TITLE
Added all_metrics to CheckpointCallback, issue #431

### DIFF
--- a/catalyst/dl/callbacks/checkpoint.py
+++ b/catalyst/dl/callbacks/checkpoint.py
@@ -98,7 +98,7 @@ class CheckpointCallback(BaseCheckpointCallback):
         self.resume = resume
         self.resume_dir = resume_dir
         self.top_best_metrics = []
-        self.all_metrics = []
+        self.epochs_metrics = []
         self._keys_from_state = ["resume", "resume_dir"]
 
     def get_checkpoint_suffix(self, checkpoint: dict) -> str:
@@ -134,7 +134,7 @@ class CheckpointCallback(BaseCheckpointCallback):
         ]
         all_epochs_metrics = [
             (f"epoch_{order_index}", valid_metric)
-            for (order_index, valid_metric) in enumerate(self.all_metrics)
+            for (order_index, valid_metric) in enumerate(self.epochs_metrics)
         ]
         best_valid_metrics = top_best_checkpoints[0][1]
         metrics = OrderedDict(
@@ -197,7 +197,7 @@ class CheckpointCallback(BaseCheckpointCallback):
         checkpoint_metric = valid_metrics[main_metric]
         metrics_record = (filepath, checkpoint_metric, valid_metrics)
         self.top_best_metrics.append(metrics_record)
-        self.all_metrics.append(metrics_record)
+        self.epochs_metrics.append(metrics_record)
         self.truncate_checkpoints(minimize_metric=minimize_metric)
         metrics = self.get_metric(valid_metrics)
         self.save_metric(logdir, metrics)

--- a/catalyst/dl/callbacks/checkpoint.py
+++ b/catalyst/dl/callbacks/checkpoint.py
@@ -55,7 +55,7 @@ class BaseCheckpointCallback(Callback):
                 epoch_metrics=epoch_metrics,
                 valid_metrics=valid_metrics,
                 stage=state.stage,
-                epoch=state.epoch,
+                epoch=state.epoch_log,
                 checkpoint_data=state.checkpoint_data
             )
             suffix = self.get_checkpoint_suffix(checkpoint)
@@ -229,7 +229,7 @@ class CheckpointCallback(BaseCheckpointCallback):
             epoch_metrics=epoch_metrics,
             valid_metrics=valid_metrics,
             stage=state.stage,
-            epoch=state.epoch,
+            epoch=state.epoch_log,
             checkpoint_data=state.checkpoint_data
         )
         self.process_checkpoint(
@@ -336,7 +336,7 @@ class IterationCheckpointCallback(BaseCheckpointCallback):
                 epoch_metrics=None,
                 valid_metrics=None,
                 stage=state.stage,
-                epoch=state.epoch
+                epoch=state.epoch_log
             )
             self.process_checkpoint(
                 logdir=state.logdir,

--- a/catalyst/dl/callbacks/checkpoint.py
+++ b/catalyst/dl/callbacks/checkpoint.py
@@ -132,16 +132,16 @@ class CheckpointCallback(BaseCheckpointCallback):
             (Path(filepath).stem, valid_metric)
             for (filepath, _, valid_metric) in self.top_best_metrics
         ]
-        all_checkpoint_metrics = [
-            (f"chekpoint_{order_index}", valid_metric)
+        all_epochs_metrics = [
+            (f"epoch_{order_index}", valid_metric)
             for (order_index, valid_metric) in enumerate(self.all_metrics)
         ]
         best_valid_metrics = top_best_checkpoints[0][1]
         metrics = OrderedDict(
             [("best", best_valid_metrics)] +
-            top_best_checkpoints +
             [("last", last_valid_metrics)] +
-            all_checkpoint_metrics
+            top_best_checkpoints +
+            all_epochs_metrics
         )
 
         self.metrics = metrics


### PR DESCRIPTION
## Description

All metrics now will be collected in list, and written with best, n_best, last checkpoint metrics.

## Related Issue

https://github.com/catalyst-team/catalyst/issues/431

## Type of Change

- [ ] Examples / docs / tutorials / contributors update
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] I have read the [CODE_OF_CONDUCT](../CODE_OF_CONDUCT.md) document.
- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [X] I have checked the code-style using `make check-style`.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.