### PR TITLE
update links to the contribution guides

### DIFF
--- a/.github/FUNDING..yml
+++ b/.github/FUNDING..yml
@@ -1,1 +1,0 @@
-patreon: catalyst_team

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: ''
 labels: bug
-assignees: Scitator, TezRomacH
+assignees:
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: ''
 labels: enhancement
-assignees: bagxi, Scitator, TezRomacH
+assignees:
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,8 +20,8 @@
 
 <!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->
 
-- [ ] I have read the [CODE_OF_CONDUCT](../CODE_OF_CONDUCT.md) document.
-- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
+- [ ] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
+- [ ] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
 - [ ] I have checked the code-style using `make check-style`.
 - [ ] I have written the docstring in Google format for all the methods and classes that I used.
 - [ ] I have checked the docs using `make check-docs`.

--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ In the **[examples folder](examples)**
 of the repository, you can find advanced tutorials and Catalyst best practices.
 
 ##### Blog
-To learn more about Catalyst internals and to be aware of the most important features, you can read [Catalyst-info](https://github.com/catalyst-team/catalyst-info), our blog where we regularly write facts about the framework.
+To learn more about Catalyst internals and to be aware of the most important features, you can read **[Catalyst-info](https://github.com/catalyst-team/catalyst-info)**, our blog where we regularly write facts about the framework.
 
 ##### Releases
 We release a major release once a month with a name like `YY.MM`.
 And micro-releases with hotfixes and framework improvements in the format `YY.MM.#`.
 
-You can view the changelog on the [GitHub Releases](https://github.com/catalyst-team/catalyst/releases) page.
+You can view the changelog on the **[GitHub Releases](https://github.com/catalyst-team/catalyst/releases)** page.
 
 Current version: [![Pipi version](https://img.shields.io/pypi/v/catalyst.svg)](https://pypi.org/project/catalyst/)
 


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
Fixed the links to the `Contributing` and `Code of Conduct`

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->
N/A

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [CODE_OF_CONDUCT](../CODE_OF_CONDUCT.md) document.
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] I have checked the code-style using `make check-style`.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.