### PR TITLE
adding learning rate, momentum, batch_time, data_time to Weights & Biases

### DIFF
--- a/catalyst/dl/runner/wandb.py
+++ b/catalyst/dl/runner/wandb.py
@@ -17,7 +17,8 @@ class WandbRunner(Runner):
     @staticmethod
     def _log_metrics(metrics: Dict, mode: str, suffix: str = ""):
         def key_locate(key: str):
-            """wandb uses first symbol _ for it service purposes
+            """
+            wandb uses first symbol _ for it service purposes
             because of that fact, we can not send original metric names
 
             Args:

--- a/catalyst/dl/runner/wandb.py
+++ b/catalyst/dl/runner/wandb.py
@@ -17,6 +17,12 @@ class WandbRunner(Runner):
     @staticmethod
     def _log_metrics(metrics: Dict, mode: str, suffix: str = ""):
         def key_locate(key: str):
+            """
+            wandb used first symbol _ for it service purposes,
+            because of that fact, we can not send original metric names
+            :param key: metric name
+            :return: formatted metric name
+            """
             if key.startswith("_"):
                 return key[1:]
             return key

--- a/catalyst/dl/runner/wandb.py
+++ b/catalyst/dl/runner/wandb.py
@@ -17,11 +17,13 @@ class WandbRunner(Runner):
     @staticmethod
     def _log_metrics(metrics: Dict, mode: str, suffix: str = ""):
         def key_locate(key: str):
-            """
-            wandb used first symbol _ for it service purposes,
+            """wandb uses first symbol _ for it service purposes
             because of that fact, we can not send original metric names
-            :param key: metric name
-            :return: formatted metric name
+
+            Args:
+                key: metric name
+            Returns:
+                formatted metric name
             """
             if key.startswith("_"):
                 return key[1:]

--- a/catalyst/dl/runner/wandb.py
+++ b/catalyst/dl/runner/wandb.py
@@ -16,8 +16,13 @@ class WandbRunner(Runner):
     """
     @staticmethod
     def _log_metrics(metrics: Dict, mode: str, suffix: str = ""):
+        def key_locate(key: str):
+            if key.startswith("_"):
+                return key[1:]
+            return key
+
         metrics = {
-            f"{key}/{mode}{suffix}": value
+            f"{key_locate(key)}/{mode}{suffix}": value
             for key, value in metrics.items()
         }
         wandb.log(metrics)


### PR DESCRIPTION
## Description

adding learning rate, momentum, batch_time, data_time to Weights & Bi

## Related Issue

https://github.com/catalyst-team/catalyst/issues/445

## Type of Change

service metrics which are started with underline symbol ```_```  were renamed to their analogues without underline symbol

wandb used first symbol ```_``` for it service purposes, because of that fact, we can not send original metric names 