### PR TITLE
fix max-size param in `catalyst/contrib/scripts/process_images.py`

### DIFF
--- a/catalyst/contrib/scripts/process_images.py
+++ b/catalyst/contrib/scripts/process_images.py
@@ -54,7 +54,7 @@ def build_args(parser):
     parser.add_argument(
         "--max-size",
         default=None,
-        required=True,
+        required=False,
         type=int,
         help="Output images size. E.g. 224, 448")
 


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
Fix broken after #398 param `max-size`
## Related Issue

<!-- If your PR refers to a related issue, link it here. -->
#398 
## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [ ] I have checked the code-style using `make check-style`.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.