### PR TITLE
`PrecisionRecallF1ScoreMeter` for Non-1D Arrays and Removing the Assertion for num_classes>1

### DIFF
--- a/catalyst/dl/core/callback.py
+++ b/catalyst/dl/core/callback.py
@@ -195,8 +195,6 @@ class MeterMetricsCallback(Callback):
         self.output_key = output_key
         self.class_names = class_names
         self.num_classes = num_classes
-        assert self.num_classes is not None and self.num_classes > 1, \
-            "`num_classes` should be an integer greater than 1."
         self.activation = activation
 
     def _reset_stats(self):

--- a/catalyst/dl/meters/ppv_tpr_f1_meter.py
+++ b/catalyst/dl/meters/ppv_tpr_f1_meter.py
@@ -73,10 +73,10 @@ class PrecisionRecallF1ScoreMeter(meter.Meter):
         Args:
             output (torch.Tensor/numpy.ndarray/numbers.Number):
                 prediction after activation function
-                shape should be (batch_size, 1)
+                shape should be (batch_size, ...)
             target (torch.Tensor/numpy.ndarray/numbers.Number):
                 label (binary)
-                shape should be (batch_size, 1)
+                shape should be the same as output's shape
         Returns:
             None
         """
@@ -86,12 +86,10 @@ class PrecisionRecallF1ScoreMeter(meter.Meter):
             target = target.cpu().squeeze().numpy()
         elif isinstance(target, numbers.Number):
             target = np.asarray([target])
-        assert np.ndim(output) == 1, \
-            "wrong output size (1D expected)"
-        assert np.ndim(target) == 1, \
-            "wrong target size (1D expected)"
+        assert output.size == target.size, \
+            "outputs and targets must have the same number of elements"
         assert output.shape[0] == target.shape[0], \
-            "number of outputs and targets does not match"
+            "batch sizes do not match."
         assert np.all(np.add(np.equal(target, 1), np.equal(target, 0))), \
             "targets should be binary (0, 1)"
 

--- a/catalyst/dl/meters/ppv_tpr_f1_meter.py
+++ b/catalyst/dl/meters/ppv_tpr_f1_meter.py
@@ -73,7 +73,7 @@ class PrecisionRecallF1ScoreMeter(meter.Meter):
         Args:
             output (torch.Tensor/numpy.ndarray/numbers.Number):
                 prediction after activation function
-                shape should be (batch_size, ...)
+                shape should be (batch_size, ...), but works with any shape
             target (torch.Tensor/numpy.ndarray/numbers.Number):
                 label (binary)
                 shape should be the same as output's shape
@@ -88,8 +88,6 @@ class PrecisionRecallF1ScoreMeter(meter.Meter):
             target = np.asarray([target])
         assert output.size == target.size, \
             "outputs and targets must have the same number of elements"
-        assert output.shape[0] == target.shape[0], \
-            "batch sizes do not match."
         assert np.all(np.add(np.equal(target, 1), np.equal(target, 0))), \
             "targets should be binary (0, 1)"
 

--- a/catalyst/dl/tests/test_ppv_tpr_f1.py
+++ b/catalyst/dl/tests/test_ppv_tpr_f1.py
@@ -71,7 +71,7 @@ def create_dummy_tensors_seg(batch_size=16, channels=1):
     return (label, pred)
 
 
-def test_meter_counts_and_value(meter, num_tp_check=16):
+def runs_tests_on_meter_counts_and_value(meter, num_tp_check=16):
     """
     Tests the meter's counts and values (ppv, tpr, f1). Assumes there are no
     fp and fn (everything is tp).
@@ -102,18 +102,18 @@ def test_meter():
     # testing .add() and .value() with tensors w/no batch size dim
     binary_y, binary_pred = create_dummy_tensors_single()
     meter.add(binary_pred, binary_y)
-    test_meter_counts_and_value(meter, num_tp_check=1)
+    runs_tests_on_meter_counts_and_value(meter, num_tp_check=1)
 
     # testing .add() and .value() with tensors w/the batch size dim
     meter.reset()
     batch_size = 16
     binary_y, binary_pred = create_dummy_tensors_batched(batch_size)
     meter.add(binary_pred, binary_y)
-    test_meter_counts_and_value(meter, num_tp_check=batch_size)
+    runs_tests_on_meter_counts_and_value(meter, num_tp_check=batch_size)
 
     # testing with seg; shape (batch_size, n_channels, h, w)
     meter.reset()
     batch_size = 16
     binary_y, binary_pred = create_dummy_tensors_seg(batch_size)
     meter.add(binary_pred, binary_y)
-    test_meter_counts_and_value(meter, num_tp_check=batch_size*15*15)
+    runs_tests_on_meter_counts_and_value(meter, num_tp_check=batch_size*15*15)


### PR DESCRIPTION
## Description
Removed certain restricting `assert` statements (in `PrecisionRecallF1ScoreMeter` and `MeterMetricsCallback`) that weren't needed to support Non-1D labels (i.e. for segmentation) for the callback and to support `num_classes==1` for single channel binary cases.

[x] tested with [segmentation](https://colab.research.google.com/drive/174KxMeJ6ZKWT603gS-tqiUNbGrkzZveb)
  * labels are single channel, so `class0` refers to foreground class

[x] figured out why binary case worked with my classification example (labels were one-hot encoded so that binary labels had 2 channels)

## Related Issue
#488 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [x] I have checked the code-style using `make check-style`.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.