### PR TITLE
Chore/verbose errors

### DIFF
--- a/catalyst/dl/scripts/run.py
+++ b/catalyst/dl/scripts/run.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from catalyst.dl.utils.scripts import import_experiment_and_runner
 from catalyst.utils import boolean_flag, prepare_cudnn, set_global_seed
 from catalyst.utils.config import dump_environment, parse_args_uargs
+from catalyst.utils.config_validator import validate_dl_config
 from catalyst.utils.scripts import dump_code
 
 
@@ -70,6 +71,7 @@ def parse_args():
 
 def main(args, unknown_args):
     args, config = parse_args_uargs(args, unknown_args)
+    config = validate_dl_config(config)
     set_global_seed(args.seed)
     prepare_cudnn(args.deterministic, args.benchmark)
 

--- a/catalyst/dl/scripts/run.py
+++ b/catalyst/dl/scripts/run.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from catalyst.dl.utils.scripts import import_experiment_and_runner
 from catalyst.utils import boolean_flag, prepare_cudnn, set_global_seed
 from catalyst.utils.config import dump_environment, parse_args_uargs
-from catalyst.utils.config_validator import validate_dl_config
+from catalyst.utils.config_validator import validate_dl_config, ConfigValidator
 from catalyst.utils.scripts import dump_code
 
 
@@ -71,7 +71,8 @@ def parse_args():
 
 def main(args, unknown_args):
     args, config = parse_args_uargs(args, unknown_args)
-    config = validate_dl_config(config)
+    #config = validate_dl_config(config)
+    ConfigValidator(config).validate()
     set_global_seed(args.seed)
     prepare_cudnn(args.deterministic, args.benchmark)
 

--- a/catalyst/utils/__init__.py
+++ b/catalyst/utils/__init__.py
@@ -10,6 +10,9 @@ from .config import (
     dump_environment, get_environment_vars, load_ordered_yaml,
     parse_args_uargs, parse_config_args
 )
+from .config_validator import (
+    validate_dl_config
+)
 # from .dataset import *
 from .ddp import get_real_module, is_wrapped_with_ddp
 # from .frozen import *

--- a/catalyst/utils/config_validator.py
+++ b/catalyst/utils/config_validator.py
@@ -1,0 +1,22 @@
+from schema import Schema, And, Optional, Forbidden
+
+dl_config_schema = Schema({
+    'model_params': {
+        'model': And(str, len)
+    },
+    'args': {
+        'expdir': And(str, len),
+        Forbidden('logdir'): '.',
+        'logdir': And(str, len),
+        'configs': object,
+        Optional(object): object
+    },
+    'stages': {
+        'stage1': object,
+        Optional(object): object
+    }
+})
+
+
+def validate_dl_config(config):
+    return dl_config_schema.validate(config)

--- a/catalyst/utils/config_validator.py
+++ b/catalyst/utils/config_validator.py
@@ -1,22 +1,92 @@
-from schema import Schema, And, Optional, Forbidden
+from schema import Schema, And, Optional, Forbidden, SchemaError
+from catalyst.dl.registry import (
+    CALLBACKS, CRITERIONS, MODELS, OPTIMIZERS, SCHEDULERS
+)
+from catalyst.utils.registry import RegistryException
 
-dl_config_schema = Schema({
-    'model_params': {
-        'model': And(str, len)
-    },
-    'args': {
-        'expdir': And(str, len),
-        Forbidden('logdir'): '.',
-        'logdir': And(str, len),
-        'configs': object,
+TOP_LEVEL_PARAMS = {
+    'model_params': object,
+    'args': object,
+    'stages': object
+}
+
+MODEL_PARAMS = {
+    'model': And(str, len)
+}
+ARGS_PARAMS = {
+    'expdir': And(str, len),
+    Forbidden('logdir'): '.',
+    'logdir': And(str, len),
+    'configs': object,
+    Optional(object): object
+}
+STAGES_PARAMS = {
+    'stage1': object,
+    'data_params': {
+        'num_workers': int,
         Optional(object): object
     },
-    'stages': {
-        'stage1': object,
-        Optional(object): object
-    }
-})
+    Optional(object): object
+}
+
+DL_CONFIG = {
+    'model_params': MODEL_PARAMS,
+    'args': ARGS_PARAMS,
+    'stages': STAGES_PARAMS
+}
 
 
 def validate_dl_config(config):
-    return dl_config_schema.validate(config)
+    return Schema(DL_CONFIG).validate(config)
+
+
+class ConfigError(Exception):
+    pass
+
+
+class ConfigValidator():
+    def __init__(self, config: dict):
+        self.config = config
+
+    def validate(self):
+        self._validate_top_level()
+        self._validate_model()
+        self._validate_args()
+        self._validate_stages()
+
+    def _validate_top_level(self):
+        try:
+            Schema(TOP_LEVEL_PARAMS).validate(self.config)
+        except SchemaError as e:
+            raise ConfigError(
+                f'You missed one of required sections in your config file:'
+                f'\n\n{e}')
+
+    def _validate_model(self):
+        try:
+            params = self.config['model_params']
+            Schema(MODEL_PARAMS).validate(params)
+            # From where I run this code now - we don't load all from expdir,
+            # so it will always throw error
+            # MODELS.get(params['model'])
+        except SchemaError as e:
+            raise ConfigError(
+                f'Your `model_params` section is not valid:\n\n{e}')
+        except RegistryException as e:
+            raise ConfigError(
+                f'You misspelled your `model` name'
+                f' in `model_params` section:\n\n{e}')
+
+    def _validate_args(self):
+        try:
+            Schema(ARGS_PARAMS).validate(self.config['args'])
+        except SchemaError as e:
+            raise ConfigError(
+                f'Your `args` section is not valid:\n\n{e}')
+
+    def _validate_stages(self):
+        try:
+            Schema(STAGES_PARAMS).validate(self.config['stages'])
+        except SchemaError as e:
+            raise ConfigError(
+                f'Your `stages` section is not valid:\n\n{e}')


### PR DESCRIPTION
## Description

> This is discussion Pull Request, it will help to decide whether Catalyst needs this kind of feature and if yes - what could be standardized and which values could use defaults and which should throw an error.

There are lots of problems with invalid configs for Catalyst, and it's not clear why something is happening without looking into sources.
Right now, you can smoothly "run" experiment, and it will show you progress and stuff but will do nothing or fail after the first validation stage.

Here are a few examples:

The smallest "working" config:

```yaml
model_params:
  model: MNISTNet

args:
  expdir: src
  logdir: logs

stages:
  stage1:
    empty: 1
```

It will do nothing at all, but no exception will be shown.

Let's add `num_workers: 0` (there is no default value, that's why it's not even started previously):

```yaml
model_params:
  model: MNISTNet

args:
  expdir: src
  logdir: logs

stages:
  data_params:
    num_workers: 0
  stage1:
    empty: 1
```

It will show progress of `1/1` epoch and will fail after validation with assertion error:

```bash
$ catalyst-dl run --config=configs/smallest.yml --verbose
1/1 * Epoch (train): 100% 100/100 [00:00<00:00, 830.36it/s]
1/1 * Epoch (valid): 100% 100/100 [00:00<00:00, 1316.28it/s]
Traceback (most recent call last):
  File "/home/gazay/anaconda3/envs/py37/bin/catalyst-dl", line 11, in <module>
    load_entry_point('catalyst', 'console_scripts', 'catalyst-dl')()
  File "/home/gazay/code/catalyst/catalyst/dl/__main__.py", line 44, in main
    COMMANDS[args.command].main(args, uargs)
  File "/home/gazay/code/catalyst/catalyst/dl/scripts/run.py", line 85, in main
    runner.run_experiment(experiment, check=args.check)
  File "/home/gazay/code/catalyst/catalyst/dl/core/runner.py", line 263, in run_experiment
    self._run_event("exception", moment=None)
  File "/home/gazay/code/catalyst/catalyst/dl/core/runner.py", line 116, in _run_event
    getattr(logger, fn_name)(self.state)
  File "/home/gazay/code/catalyst/catalyst/dl/callbacks/misc.py", line 155, in on_exception
    raise exception
  File "/home/gazay/code/catalyst/catalyst/dl/core/runner.py", line 260, in run_experiment
    self._run_stage(stage)
  File "/home/gazay/code/catalyst/catalyst/dl/core/runner.py", line 234, in _run_stage
    self._run_event("epoch", moment="end")
  File "/home/gazay/code/catalyst/catalyst/dl/core/runner.py", line 101, in _run_event
    getattr(self.state, f"{fn_name}_pre")()
  File "/home/gazay/code/catalyst/catalyst/dl/core/state.py", line 147, in on_epoch_end_pre
    self.metrics.end_epoch_train()
  File "/home/gazay/code/catalyst/catalyst/dl/core/metric_manager.py", line 93, in end_epoch_train
    f"{self._main_metric} value is not available by the epoch end"
AssertionError: loss value is not available by the epoch end
```
That's because some of the parts set from defaults (`batch_size` for example to `1`, `main_metric` to `loss` and so on), but all other required parts of supervised training are missed - optimizer, criterion, scheduler. And it's tough to find what is the problem and how to fix it from those error messages.

I propose to standardize defaults for config parameters where it's applicable and to create a config validation system with verbose exception messages. They also can contain links to guides/tutorials on the topic and will prevent `empty` runs and help users to find the problem faster.

Also, it would be great to show the user what is default value of variable it didn't set before run (maybe pretty-printed of config dict after validation could work or warning).

In this Pull Request I provided two different PoCs on validation part with the help of [schema](https://github.com/keleshev/schema) validator:

1. We just describe everything in `Schema` format and leave it with default `Schema` errors (`validate_dl_config` method in `config_validator.py`). It's very simple and straightforward and a little bit more readable than some python assert/type/method errors:

```bash
$ catalyst-dl run --config=configs/smallest.yml --verbose
Traceback (most recent call last):
  File "/home/gazay/anaconda3/envs/py37/lib/python3.7/site-packages/schema.py", line 393, in validate
    nvalue = Schema(svalue, error=e, ignore_extra_keys=i).validate(value)
  File "/home/gazay/anaconda3/envs/py37/lib/python3.7/site-packages/schema.py", line 408, in validate
    raise SchemaMissingKeyError(message, e)
schema.SchemaMissingKeyError: Missing key: 'data_params'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/gazay/anaconda3/envs/py37/bin/catalyst-dl", line 11, in <module>
    load_entry_point('catalyst', 'console_scripts', 'catalyst-dl')()
  File "/home/gazay/code/catalyst/catalyst/dl/__main__.py", line 44, in main
    COMMANDS[args.command].main(args, uargs)
  File "/home/gazay/code/catalyst/catalyst/dl/scripts/run.py", line 74, in main
    config = validate_dl_config(config)
  File "/home/gazay/code/catalyst/catalyst/utils/config_validator.py", line 40, in validate_dl_config
    return Schema(DL_CONFIG).validate(config)
  File "/home/gazay/anaconda3/envs/py37/lib/python3.7/site-packages/schema.py", line 397, in validate
    raise SchemaError([message] + x.autos, [e] + x.errors)
schema.SchemaError: Key 'stages' error:
Missing key: 'data_params'
```

2. We can wrap validator with higher-level object and provide more informative errors for every part of config file. It can possibly provide more readable error messages, and in some cases with directions and links to guides and tutorials - how to solve problem and what API there possible can be used.

```bash
$ catalyst-dl run --config=configs/smallest.yml --verbose
Traceback (most recent call last):
  File "/home/gazay/code/catalyst/catalyst/utils/config_validator.py", line 68, in _validate_model
    Schema(MODEL_PARAMS).validate(params)
  File "/home/gazay/anaconda3/envs/py37/lib/python3.7/site-packages/schema.py", line 408, in validate
    raise SchemaMissingKeyError(message, e)
schema.SchemaMissingKeyError: Missing key: 'model'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/gazay/anaconda3/envs/py37/bin/catalyst-dl", line 11, in <module>
    load_entry_point('catalyst', 'console_scripts', 'catalyst-dl')()
  File "/home/gazay/code/catalyst/catalyst/dl/__main__.py", line 44, in main
    COMMANDS[args.command].main(args, uargs)
  File "/home/gazay/code/catalyst/catalyst/dl/scripts/run.py", line 75, in main
    ConfigValidator(config).validate()
  File "/home/gazay/code/catalyst/catalyst/utils/config_validator.py", line 53, in validate
    self._validate_model()
  File "/home/gazay/code/catalyst/catalyst/utils/config_validator.py", line 74, in _validate_model
    f'Your `model_params` section is not valid:\n\n{e}'
catalyst.utils.config_validator.ConfigError: Your `model_params` section is not valid:

Missing key: 'model'

You can read how to add model here: https://github.com/link-to-tutorial-or-doc
```


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [ ] I have checked the code-style using `make check-style`.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.