### PR TITLE
Revet model.to(device) call before amp.initialize

### DIFF
--- a/catalyst/dl/utils/torch.py
+++ b/catalyst/dl/utils/torch.py
@@ -28,6 +28,8 @@ def process_components(
     if device is None:
         device = utils.get_device()
 
+    model = maybe_recursive_call(model, "to", device=device)
+
     if utils.is_wrapped_with_ddp(model):
         pass
     elif len(distributed_params) > 0:


### PR DESCRIPTION
## Description

Remove model.to(device) cause an exception on amp.initialization call

```
Traceback (most recent call last):
  File "/home/va/.pyenv/versions/3.7.4/envs/clouds-catalyst/lib/python3.7/site-packages/catalyst/dl/core/runner.py", line 260, in run_experiment
    self._run_stage(stage)
  File "/home/va/.pyenv/versions/3.7.4/envs/clouds-catalyst/lib/python3.7/site-packages/catalyst/dl/core/runner.py", line 209, in _run_stage
    self._prepare_for_stage(stage)
  File "/home/va/.pyenv/versions/3.7.4/envs/clouds-catalyst/lib/python3.7/site-packages/catalyst/dl/core/runner.py", line 80, in _prepare_for_stage
    self._get_experiment_components(stage)
  File "/home/va/.pyenv/versions/3.7.4/envs/clouds-catalyst/lib/python3.7/site-packages/catalyst/dl/core/runner.py", line 63, in _get_experiment_components
    device=self.device
  File "/home/va/.pyenv/versions/3.7.4/envs/clouds-catalyst/lib/python3.7/site-packages/catalyst/dl/utils/torch.py", line 49, in process_components
    model, optimizer, **distributed_params
  File "/home/va/.pyenv/versions/3.7.4/envs/clouds-catalyst/lib/python3.7/site-packages/apex/amp/frontend.py", line 358, in initialize
    return _initialize(models, optimizers, _amp_state.opt_properties, num_losses, cast_model_outputs)
  File "/home/va/.pyenv/versions/3.7.4/envs/clouds-catalyst/lib/python3.7/site-packages/apex/amp/_initialize.py", line 171, in _initialize
    check_params_fp32(models)
  File "/home/va/.pyenv/versions/3.7.4/envs/clouds-catalyst/lib/python3.7/site-packages/apex/amp/_initialize.py", line 93, in check_params_fp32
    name, param.type()))
  File "/home/va/.pyenv/versions/3.7.4/envs/clouds-catalyst/lib/python3.7/site-packages/apex/amp/_amp_state.py", line 32, in warn_or_err
    raise RuntimeError(msg)
RuntimeError: Found param encoder.conv2d_1a.conv.weight with type torch.FloatTensor, expected torch.cuda.FloatTensor.
When using amp.initialize, you need to provide a model with parameters
located on a CUDA device before passing it no matter what optimization level
you chose. Use model.to('cuda') to use the default device.

During handling of the above exception, another exception occurred:
```

## Related Issue

#482 

## Type of Change

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [ ] I have checked the code-style using `make check-style`.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.