### PR TITLE
Chore/default callbacks for ConfigExperiment

### DIFF
--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -13,7 +13,8 @@ from torch.utils.data import (  # noqa F401
 from catalyst.dl import utils
 from catalyst.dl.callbacks import (
     CheckpointCallback, ConsoleLogger, CriterionCallback, OptimizerCallback,
-    RaiseExceptionCallback, SchedulerCallback, TensorboardLogger, VerboseLogger
+    RaiseExceptionCallback, SchedulerCallback, TensorboardLogger,
+    VerboseLogger
 )
 from catalyst.dl.core import Callback, Experiment
 from catalyst.dl.registry import (

--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -13,8 +13,8 @@ from torch.utils.data import (  # noqa F401
 from catalyst.dl import utils
 from catalyst.dl.callbacks import (
     CheckpointCallback, ConsoleLogger, CriterionCallback, OptimizerCallback,
-    RaiseExceptionCallback, SchedulerCallback, TensorboardLogger,
-    VerboseLogger
+    PhaseWrapperCallback, RaiseExceptionCallback, SchedulerCallback,
+    TensorboardLogger, VerboseLogger
 )
 from catalyst.dl.core import Callback, Experiment
 from catalyst.dl.registry import (
@@ -414,9 +414,13 @@ class ConfigExperiment(Experiment):
         default_callbacks.append(("exception", RaiseExceptionCallback))
 
         for callback_name, callback_fn in default_callbacks:
-            is_already_present = any(
-                isinstance(x, callback_fn) for x in callbacks.values()
-            )
+            is_already_present = False
+            for x in callbacks.values():
+                if isinstance(x, PhaseWrapperCallback):
+                    x = x.callback
+                if isinstance(x, callback_fn):
+                    is_already_present = True
+                    break
             if not is_already_present:
                 callbacks[callback_name] = callback_fn()
 

--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -13,7 +13,7 @@ from torch.utils.data import (  # noqa F401
 from catalyst.dl import utils
 from catalyst.dl.callbacks import (
     CriterionCallback, ConsoleLogger, CheckpointCallback, OptimizerCallback,
-    RaiseExceptionCallback, TensorboardLogger, VerboseLogger
+    SchedulerCallback, RaiseExceptionCallback, TensorboardLogger, VerboseLogger
 )
 from catalyst.dl.core import Callback, Experiment
 from catalyst.dl.registry import (
@@ -404,6 +404,8 @@ class ConfigExperiment(Experiment):
         if not stage.startswith("infer"):
             default_callbacks.append(("_criterion", CriterionCallback))
             default_callbacks.append(("_optimizer", OptimizerCallback))
+            if self.stages_config[stage].get("scheduler_params", {}):
+                default_callbacks.append(("_scheduler", SchedulerCallback))
             default_callbacks.append(("_saver", CheckpointCallback))
             default_callbacks.append(("console", ConsoleLogger))
             default_callbacks.append(("tensorboard", TensorboardLogger))

--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -12,8 +12,8 @@ from torch.utils.data import (  # noqa F401
 
 from catalyst.dl import utils
 from catalyst.dl.callbacks import (
-    CriterionCallback, ConsoleLogger, CheckpointCallback, OptimizerCallback,
-    SchedulerCallback, RaiseExceptionCallback, TensorboardLogger, VerboseLogger
+    CheckpointCallback, ConsoleLogger, CriterionCallback, OptimizerCallback,
+    RaiseExceptionCallback, SchedulerCallback, TensorboardLogger, VerboseLogger
 )
 from catalyst.dl.core import Callback, Experiment
 from catalyst.dl.registry import (

--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -12,7 +12,8 @@ from torch.utils.data import (  # noqa F401
 
 from catalyst.dl import utils
 from catalyst.dl.callbacks import (
-    ConsoleLogger, RaiseExceptionCallback, TensorboardLogger, VerboseLogger
+    CriterionCallback, ConsoleLogger, CheckpointCallback, OptimizerCallback,
+    RaiseExceptionCallback, TensorboardLogger, VerboseLogger
 )
 from catalyst.dl.core import Callback, Experiment
 from catalyst.dl.registry import (
@@ -401,6 +402,9 @@ class ConfigExperiment(Experiment):
         if self._verbose:
             default_callbacks.append(("verbose", VerboseLogger))
         if not stage.startswith("infer"):
+            default_callbacks.append(("_criterion", CriterionCallback))
+            default_callbacks.append(("_optimizer", OptimizerCallback))
+            default_callbacks.append(("_saver", CheckpointCallback))
             default_callbacks.append(("console", ConsoleLogger))
             default_callbacks.append(("tensorboard", TensorboardLogger))
 

--- a/catalyst/dl/experiment/supervised.py
+++ b/catalyst/dl/experiment/supervised.py
@@ -14,27 +14,22 @@ class SupervisedExperiment(BaseExperiment):
         callbacks = self._callbacks
         default_callbacks = []
         if self._verbose:
-            default_callbacks.append(
-                ("_verbose_logger", "verbose", VerboseLogger)
-            )
+            default_callbacks.append(("verbose", VerboseLogger))
         if not stage.startswith("infer"):
-            default_callbacks.extend([
-                (self._criterion, "_criterion", CriterionCallback),
-                (self._optimizer, "_optimizer", OptimizerCallback),
-                (self._scheduler, "_scheduler", SchedulerCallback),
-                ("_default_saver", "_saver", CheckpointCallback),
-                ("_console_logger", "console", ConsoleLogger),
-                ("_tensorboard_logger", "tensorboard", TensorboardLogger)
-            ])
-        default_callbacks.append(
-            ("_exception", "exception", RaiseExceptionCallback)
-        )
+            default_callbacks.append(("_criterion", CriterionCallback))
+            default_callbacks.append(("_optimizer", OptimizerCallback))
+            if self._scheduler is not None:
+                default_callbacks.append(("_scheduler", SchedulerCallback))
+            default_callbacks.append(("_saver", CheckpointCallback))
+            default_callbacks.append(("console", ConsoleLogger))
+            default_callbacks.append(("tensorboard", TensorboardLogger))
+        default_callbacks.append(("exception", RaiseExceptionCallback))
 
-        for component, callback_name, callback_fn in default_callbacks:
+        for callback_name, callback_fn in default_callbacks:
             is_already_present = any(
                 isinstance(x, callback_fn) for x in callbacks.values()
             )
-            if component is not None and not is_already_present:
+            if not is_already_present:
                 callbacks[callback_name] = callback_fn()
         return callbacks
 

--- a/catalyst/dl/experiment/supervised.py
+++ b/catalyst/dl/experiment/supervised.py
@@ -10,7 +10,38 @@ from .base import BaseExperiment
 
 
 class SupervisedExperiment(BaseExperiment):
+    """
+    Supervised experiment used mostly in Notebook API
+        The main difference with BaseExperiment that it will
+        add several callbacks by default if you haven't.
+
+        Here are list of callbacks by default:
+            CriterionCallback:
+                measures loss with specified ``criterion``.
+            OptimizerCallback: abstraction over ``optimizer`` step.
+            SchedulerCallback: only in case if you provided scheduler to your
+                experiment does `lr_scheduler.step`
+            CheckpointCallback: saves model and optimizer state each epoch
+                callback to save/restore your
+                model/criterion/optimizer/metrics.
+            ConsoleLogger: standard Catalyst logger, translates
+                ``state.metrics`` to console and text file
+            TensorboardLogger: will write ``state.metrics`` to tensorboard
+            RaiseExceptionCallback: will raise exception if needed
+    """
+
     def get_callbacks(self, stage: str) -> "OrderedDict[str, Callback]":
+        """
+        Override of ``BaseExperiment.get_callbacks`` method.
+        Will add several of callbacks by default in case they missed.
+
+        Args:
+            stage (str): name of stage. It should start with `infer` if you
+                don't need default callbacks, as they required only for
+                training stages.
+        Returns:
+            List[Callback]: list of callbacks for experiment
+        """
         callbacks = self._callbacks
         default_callbacks = []
         if self._verbose:

--- a/catalyst/dl/experiment/supervised.py
+++ b/catalyst/dl/experiment/supervised.py
@@ -10,24 +10,29 @@ from .base import BaseExperiment
 
 
 class SupervisedExperiment(BaseExperiment):
-    """
-    Supervised experiment used mostly in Notebook API
-        The main difference with BaseExperiment that it will
-        add several callbacks by default if you haven't.
+    """Supervised experiment used mostly in Notebook API
 
-        Here are list of callbacks by default:
-            CriterionCallback:
-                measures loss with specified ``criterion``.
-            OptimizerCallback: abstraction over ``optimizer`` step.
-            SchedulerCallback: only in case if you provided scheduler to your
-                experiment does `lr_scheduler.step`
-            CheckpointCallback: saves model and optimizer state each epoch
-                callback to save/restore your
-                model/criterion/optimizer/metrics.
-            ConsoleLogger: standard Catalyst logger, translates
-                ``state.metrics`` to console and text file
-            TensorboardLogger: will write ``state.metrics`` to tensorboard
-            RaiseExceptionCallback: will raise exception if needed
+    The main difference with BaseExperiment that it will
+    add several callbacks by default if you haven't.
+
+    Here are list of callbacks by default:
+        CriterionCallback:
+            measures loss with specified ``criterion``.
+        OptimizerCallback:
+            abstraction over ``optimizer`` step.
+        SchedulerCallback:
+            only in case if you provided scheduler to your experiment does
+            `lr_scheduler.step`
+        CheckpointCallback:
+            saves model and optimizer state each epoch callback to save/restore
+            your model/criterion/optimizer/metrics.
+        ConsoleLogger:
+            standard Catalyst logger, translates ``state.metrics`` to console
+            and text file
+        TensorboardLogger:
+            will write ``state.metrics`` to tensorboard
+        RaiseExceptionCallback:
+            will raise exception if needed
     """
 
     def get_callbacks(self, stage: str) -> "OrderedDict[str, Callback]":

--- a/catalyst/dl/experiment/tests/test_base.py
+++ b/catalyst/dl/experiment/tests/test_base.py
@@ -6,6 +6,10 @@ from catalyst.dl.experiment.base import BaseExperiment
 
 
 def test_defaults():
+    """
+    Test on defaults for BaseExperiment. It will be useful if we decide to
+    change anything in those values as it could make breaking change.
+    """
     model = torch.nn.Module()
     dataset = torch.utils.data.Dataset()
     dataloader = torch.utils.data.DataLoader(dataset)

--- a/catalyst/dl/experiment/tests/test_base.py
+++ b/catalyst/dl/experiment/tests/test_base.py
@@ -1,0 +1,34 @@
+import torch
+from collections import OrderedDict
+from catalyst.dl.experiment.base import BaseExperiment
+
+
+def test_defaults():
+    model = torch.nn.Module()
+    dataset = torch.utils.data.Dataset()
+    dataloader = torch.utils.data.DataLoader(dataset)
+    loaders = OrderedDict()
+    loaders['train'] = dataloader
+
+    exp = BaseExperiment(model=model, loaders=loaders)
+
+    assert exp.initial_seed == 42
+    assert exp.logdir is None
+    assert exp.stages == ["train"]
+    assert exp.distributed_params == {}
+    assert exp.monitoring_params == {}
+    assert exp.get_state_params('') == {
+        'logdir': None,
+        'num_epochs': 1,
+        'valid_loader': "valid",
+        'main_metric': "loss",
+        'verbose': False,
+        'minimize_metric': True,
+        'checkpoint_data': {},
+    }
+    assert exp.get_model('') == model
+    assert exp.get_criterion('') is None
+    assert exp.get_optimizer('', model) is None
+    assert exp.get_scheduler('') is None
+    assert exp.get_callbacks('') == OrderedDict()
+    assert exp.get_loaders('') == loaders

--- a/catalyst/dl/experiment/tests/test_base.py
+++ b/catalyst/dl/experiment/tests/test_base.py
@@ -1,5 +1,7 @@
-import torch
 from collections import OrderedDict
+
+import torch
+
 from catalyst.dl.experiment.base import BaseExperiment
 
 
@@ -8,7 +10,7 @@ def test_defaults():
     dataset = torch.utils.data.Dataset()
     dataloader = torch.utils.data.DataLoader(dataset)
     loaders = OrderedDict()
-    loaders['train'] = dataloader
+    loaders["train"] = dataloader
 
     exp = BaseExperiment(model=model, loaders=loaders)
 
@@ -17,18 +19,18 @@ def test_defaults():
     assert exp.stages == ["train"]
     assert exp.distributed_params == {}
     assert exp.monitoring_params == {}
-    assert exp.get_state_params('') == {
-        'logdir': None,
-        'num_epochs': 1,
-        'valid_loader': "valid",
-        'main_metric': "loss",
-        'verbose': False,
-        'minimize_metric': True,
-        'checkpoint_data': {},
+    assert exp.get_state_params("") == {
+        "logdir": None,
+        "num_epochs": 1,
+        "valid_loader": "valid",
+        "main_metric": "loss",
+        "verbose": False,
+        "minimize_metric": True,
+        "checkpoint_data": {},
     }
-    assert exp.get_model('') == model
-    assert exp.get_criterion('') is None
-    assert exp.get_optimizer('', model) is None
-    assert exp.get_scheduler('') is None
-    assert exp.get_callbacks('') == OrderedDict()
-    assert exp.get_loaders('') == loaders
+    assert exp.get_model("") == model
+    assert exp.get_criterion("") is None
+    assert exp.get_optimizer("", model) is None
+    assert exp.get_scheduler("") is None
+    assert exp.get_callbacks("") == OrderedDict()
+    assert exp.get_loaders("") == loaders

--- a/catalyst/dl/experiment/tests/test_config.py
+++ b/catalyst/dl/experiment/tests/test_config.py
@@ -1,0 +1,69 @@
+import pytest
+
+import torch
+from collections import OrderedDict
+from catalyst.dl.experiment.config import ConfigExperiment
+from catalyst.dl import registry
+from catalyst.dl.callbacks import (
+    CriterionCallback, ConsoleLogger, CheckpointCallback, OptimizerCallback,
+    RaiseExceptionCallback, TensorboardLogger
+)
+
+
+DEFAULT_MINIMAL_CONFIG = {
+    "model_params": {
+        "model": "SomeModel"
+    },
+    "stages": {
+        "data_params": {
+            "num_workers": 0
+        },
+        "train": {}
+    }
+}
+
+
+DEFAULT_CALLBACKS = OrderedDict([
+    ('_criterion', CriterionCallback),
+    ('_optimizer', OptimizerCallback),
+    ('_saver', CheckpointCallback),
+    ('console', ConsoleLogger),
+    ('tensorboard', TensorboardLogger),
+    ('exception', RaiseExceptionCallback)])
+
+
+class SomeModel(torch.nn.Module):
+    pass
+
+
+registry.MODELS.add(SomeModel)
+
+
+def test_defaults():
+    exp = ConfigExperiment(config=DEFAULT_MINIMAL_CONFIG)
+
+    assert exp.initial_seed == 42
+    assert exp.logdir is None
+    assert exp.stages == ["train"]
+    assert exp.distributed_params == {}
+    assert exp.monitoring_params == {}
+    assert exp.get_state_params("train") == {
+        "logdir": None,
+    }
+    assert isinstance(exp.get_model("train"), SomeModel)
+    assert exp.get_criterion("train") is None
+    assert exp.get_optimizer("train", SomeModel()) is None
+    assert exp.get_scheduler("train", None) is None
+    assert exp.get_callbacks("train").keys() == DEFAULT_CALLBACKS.keys()
+    cbs = zip(exp.get_callbacks("train").values(), DEFAULT_CALLBACKS.values())
+    for c1, klass in cbs:
+        assert isinstance(c1, klass)
+
+
+def test_not_implemented_datasets():
+    exp = ConfigExperiment(config=DEFAULT_MINIMAL_CONFIG)
+
+    with pytest.raises(NotImplementedError):
+        exp.get_loaders("train")
+    with pytest.raises(NotImplementedError):
+        exp.get_datasets("train")

--- a/catalyst/dl/experiment/tests/test_config.py
+++ b/catalyst/dl/experiment/tests/test_config.py
@@ -1,14 +1,15 @@
+from collections import OrderedDict
+
 import pytest
 
 import torch
-from collections import OrderedDict
-from catalyst.dl.experiment.config import ConfigExperiment
+
 from catalyst.dl import registry
 from catalyst.dl.callbacks import (
-    CriterionCallback, ConsoleLogger, CheckpointCallback, OptimizerCallback,
+    CheckpointCallback, ConsoleLogger, CriterionCallback, OptimizerCallback,
     RaiseExceptionCallback, TensorboardLogger
 )
-
+from catalyst.dl.experiment.config import ConfigExperiment
 
 DEFAULT_MINIMAL_CONFIG = {
     "model_params": {
@@ -24,12 +25,12 @@ DEFAULT_MINIMAL_CONFIG = {
 
 
 DEFAULT_CALLBACKS = OrderedDict([
-    ('_criterion', CriterionCallback),
-    ('_optimizer', OptimizerCallback),
-    ('_saver', CheckpointCallback),
-    ('console', ConsoleLogger),
-    ('tensorboard', TensorboardLogger),
-    ('exception', RaiseExceptionCallback)])
+    ("_criterion", CriterionCallback),
+    ("_optimizer", OptimizerCallback),
+    ("_saver", CheckpointCallback),
+    ("console", ConsoleLogger),
+    ("tensorboard", TensorboardLogger),
+    ("exception", RaiseExceptionCallback)])
 
 
 class SomeModel(torch.nn.Module):

--- a/catalyst/dl/experiment/tests/test_config.py
+++ b/catalyst/dl/experiment/tests/test_config.py
@@ -34,6 +34,9 @@ DEFAULT_CALLBACKS = OrderedDict([
 
 
 class SomeModel(torch.nn.Module):
+    """
+    Dummy test torch model
+    """
     pass
 
 
@@ -41,6 +44,12 @@ registry.MODELS.add(SomeModel)
 
 
 def test_defaults():
+    """
+    Test on ConfigExperiment defaults. It's pretty similar to BaseExperiment's
+    test but the thing is that those two are very different classes and
+    inherits from different parent classes.
+    Also very important to check which callbacks are added by default
+    """
     exp = ConfigExperiment(config=DEFAULT_MINIMAL_CONFIG)
 
     assert exp.initial_seed == 42
@@ -62,6 +71,10 @@ def test_defaults():
 
 
 def test_not_implemented_datasets():
+    """
+    Test on ``get_datasets`` method, which should be implememnted by user.
+    Method ``get_loaders`` will call ``get_dataset``.
+    """
     exp = ConfigExperiment(config=DEFAULT_MINIMAL_CONFIG)
 
     with pytest.raises(NotImplementedError):

--- a/catalyst/dl/experiment/tests/test_supervised.py
+++ b/catalyst/dl/experiment/tests/test_supervised.py
@@ -8,6 +8,8 @@ from catalyst.dl.callbacks import (
 
 
 DEFAULT_CALLBACKS = OrderedDict([
+    ('_criterion', CriterionCallback),
+    ('_optimizer', OptimizerCallback),
     ('_saver', CheckpointCallback),
     ('console', ConsoleLogger),
     ('tensorboard', TensorboardLogger),

--- a/catalyst/dl/experiment/tests/test_supervised.py
+++ b/catalyst/dl/experiment/tests/test_supervised.py
@@ -1,19 +1,20 @@
-import torch
 from collections import OrderedDict
-from catalyst.dl.experiment.supervised import SupervisedExperiment
+
+import torch
+
 from catalyst.dl.callbacks import (
-    CriterionCallback, ConsoleLogger, CheckpointCallback, OptimizerCallback,
+    CheckpointCallback, ConsoleLogger, CriterionCallback, OptimizerCallback,
     RaiseExceptionCallback, TensorboardLogger
 )
-
+from catalyst.dl.experiment.supervised import SupervisedExperiment
 
 DEFAULT_CALLBACKS = OrderedDict([
-    ('_criterion', CriterionCallback),
-    ('_optimizer', OptimizerCallback),
-    ('_saver', CheckpointCallback),
-    ('console', ConsoleLogger),
-    ('tensorboard', TensorboardLogger),
-    ('exception', RaiseExceptionCallback)])
+    ("_criterion", CriterionCallback),
+    ("_optimizer", OptimizerCallback),
+    ("_saver", CheckpointCallback),
+    ("console", ConsoleLogger),
+    ("tensorboard", TensorboardLogger),
+    ("exception", RaiseExceptionCallback)])
 
 
 def test_defaults():
@@ -21,7 +22,7 @@ def test_defaults():
     dataset = torch.utils.data.Dataset()
     dataloader = torch.utils.data.DataLoader(dataset)
     loaders = OrderedDict()
-    loaders['train'] = dataloader
+    loaders["train"] = dataloader
 
     exp = SupervisedExperiment(model=model, loaders=loaders)
 

--- a/catalyst/dl/experiment/tests/test_supervised.py
+++ b/catalyst/dl/experiment/tests/test_supervised.py
@@ -1,0 +1,29 @@
+import torch
+from collections import OrderedDict
+from catalyst.dl.experiment.supervised import SupervisedExperiment
+from catalyst.dl.callbacks import (
+    CriterionCallback, ConsoleLogger, CheckpointCallback, OptimizerCallback,
+    RaiseExceptionCallback, TensorboardLogger
+)
+
+
+DEFAULT_CALLBACKS = OrderedDict([
+    ('_saver', CheckpointCallback),
+    ('console', ConsoleLogger),
+    ('tensorboard', TensorboardLogger),
+    ('exception', RaiseExceptionCallback)])
+
+
+def test_defaults():
+    model = torch.nn.Module()
+    dataset = torch.utils.data.Dataset()
+    dataloader = torch.utils.data.DataLoader(dataset)
+    loaders = OrderedDict()
+    loaders['train'] = dataloader
+
+    exp = SupervisedExperiment(model=model, loaders=loaders)
+
+    assert exp.get_callbacks("train").keys() == DEFAULT_CALLBACKS.keys()
+    cbs = zip(exp.get_callbacks("train").values(), DEFAULT_CALLBACKS.values())
+    for cb, klass in cbs:
+        assert isinstance(cb, klass)

--- a/catalyst/dl/experiment/tests/test_supervised.py
+++ b/catalyst/dl/experiment/tests/test_supervised.py
@@ -18,6 +18,11 @@ DEFAULT_CALLBACKS = OrderedDict([
 
 
 def test_defaults():
+    """
+    Test on defaults for SupervisedExperiment class, which is child class of
+    BaseExperiment.  That's why we check only default callbacks functionality
+    here
+    """
     model = torch.nn.Module()
     dataset = torch.utils.data.Dataset()
     dataloader = torch.utils.data.DataLoader(dataset)
@@ -28,5 +33,5 @@ def test_defaults():
 
     assert exp.get_callbacks("train").keys() == DEFAULT_CALLBACKS.keys()
     cbs = zip(exp.get_callbacks("train").values(), DEFAULT_CALLBACKS.values())
-    for cb, klass in cbs:
-        assert isinstance(cb, klass)
+    for callback, klass in cbs:
+        assert isinstance(callback, klass)


### PR DESCRIPTION
## Description

I've added few tests on experiments and few default callbacks to `ConfigExperiment`.

I think that some of the callbacks should be set by default in non-infer mode in `SupervisedExperiment` and `ConfigExperiment`.

Right now, you can skip setting of `Criterion` and `Optimizer` for `Supervised` and `Config` experiments. Still, I think it could be right only for very rare edge cases in non-infer mode (I can't think of one).

In `SupervisedExperiment`, there is a check that if `Criterion` set in `non-infer` mode - then we should set default `CriterionCallback` if there is none. I think this kind of flexibility is not suitable for `Supervised` and `Config` experiments as absence of those callbacks makes no sense the same as absence of `Criterion` and `Optimizer` itself - without them, the experiment will be just iteration through data.

As result:

1. It should be almost impossible to run training without optimization process (if user forget to set criterion for example or misspelled key for it in config file) from `Supervised` and from `Config` experiments without exception being raised.
2. Users will set `callback_params` in config file only when they need to change something from defaults.

## Related Issue

https://github.com/catalyst-team/catalyst/pull/496

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [ ] I have checked the code-style using `make check-style`.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.