### PR TITLE
Add sampler-wide random seed forwarded from run_samplers script

### DIFF
--- a/catalyst/rl/core/sampler.py
+++ b/catalyst/rl/core/sampler.py
@@ -174,7 +174,8 @@ class Sampler:
 
     def _get_seed(self):
         if self.trajectory_seeds is not None:
-            seed = self.trajectory_seeds[self.trajectory_index % len(self.trajectory_seeds)]
+            seed = self.trajectory_seeds[
+                self.trajectory_index % len(self.trajectory_seeds)]
         else:
             seed = self._seeder()[0]
         set_global_seed(seed)

--- a/catalyst/rl/scripts/run_samplers.py
+++ b/catalyst/rl/scripts/run_samplers.py
@@ -148,7 +148,8 @@ def run_sampler(
         id=id,
         mode=mode,
         weights_sync_mode=weights_sync_mode,
-        seeds=seeds,
+        sampler_seed=seed,
+        trajectory_seeds=seeds,
         monitoring_params=monitoring_params,
         **config_["sampler"],
     )


### PR DESCRIPTION
## Description

Forward global seed from `run_samplers` to every sampler instead of hard coded random seed as it was before.

## Related Issue

#525 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [x] I have checked the code-style using `make check-style`.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.