### PR TITLE
Fix missing metrics in Tensorboard

### DIFF
--- a/catalyst/dl/core/state.py
+++ b/catalyst/dl/core/state.py
@@ -156,10 +156,10 @@ class RunnerState(FrozenClass):
         pass
 
     def on_loader_end_pre(self):
-        pass
+        self.metrics.end_loader()
 
     def on_loader_end_post(self):
-        self.metrics.end_loader()
+        pass
 
     def on_batch_start_pre(self):
         self.metrics.begin_batch()


### PR DESCRIPTION
## Description

This fixes missing metrics in Tensorboard that are computed as mean across batch values.
The error was caused by too late invocation of  `self.metrics.end_loader()` in `on_loader_end_post()`. By that time, TensorboardLogger callback has been already called, but `epoch_values` were not filled.
The fix is to move `self.metrics.end_loader()` to `on_loader_end_pre` step, to ensure we compute epoch values before running through `loader_end` event.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [x] I have checked the code-style using `make check-style`.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.