### PR TITLE
Fix bug in IoU calculation

### DIFF
--- a/catalyst/dl/utils/criterion/iou.py
+++ b/catalyst/dl/utils/criterion/iou.py
@@ -30,7 +30,7 @@ def iou(
 
     intersection = torch.sum(targets * outputs)
     union = torch.sum(targets) + torch.sum(outputs)
-    iou = intersection / (union - intersection + eps)
+    iou = (intersection + eps) / (union - intersection + eps)
 
     return iou
 


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

Bug: IoU equals 0 if target and output are both empty.
From [wiki](https://en.wikipedia.org/wiki/Jaccard_index): If A and B are both empty, define J(A, B) = 1

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [ ] I have checked the code-style using `make check-style`.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.