### PR TITLE
Remove excess requirements installation line from docker files

### DIFF
--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -25,7 +25,6 @@ CMD mkdir -p /workspace
 COPY requirements/ /workspace/
 RUN pip install -r /workspace/requirements.txt --no-cache-dir \
     && pip install -r /workspace/requirements-rl.txt --no-cache-dir \
-    && pip install -r /workspace/requirements-dl.txt --no-cache-dir \
     && pip install -r /workspace/requirements-contrib.txt --no-cache-dir \
     && pip install -r /workspace/requirements-dev.txt --no-cache-dir
 

--- a/docker/Dockerfile-dev-fp16
+++ b/docker/Dockerfile-dev-fp16
@@ -25,7 +25,6 @@ CMD mkdir -p /workspace
 COPY requirements/ /workspace/
 RUN pip install -r /workspace/requirements.txt --no-cache-dir \
     && pip install -r /workspace/requirements-rl.txt --no-cache-dir \
-    && pip install -r /workspace/requirements-dl.txt --no-cache-dir \
     && pip install -r /workspace/requirements-contrib.txt --no-cache-dir \
     && pip install -r /workspace/requirements-dev.txt --no-cache-dir
 


### PR DESCRIPTION
## Description

Currently `make docker-dev` and `make docker-dev-fp16` are broken because there is no requirements file `requirements-dl.txt` in requirements folder.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [x] I have checked the code-style using `make check-style`.
- [x] I have written the docstring in Google format for all the methods and classes that I used.
- [x] I have checked the docs using `make check-docs`.