### PR TITLE
Do not ignore `verbose` and `check` args values if they are set in config file

### DIFF
--- a/catalyst/dl/scripts/run.py
+++ b/catalyst/dl/scripts/run.py
@@ -4,6 +4,8 @@ import argparse
 from argparse import ArgumentParser
 from pathlib import Path
 
+import safitty
+
 from catalyst.dl.utils.scripts import import_experiment_and_runner
 from catalyst.utils import boolean_flag, prepare_cudnn, set_global_seed
 from catalyst.utils.config import dump_environment, parse_args_uargs
@@ -45,8 +47,8 @@ def build_args(parser: ArgumentParser):
         help="path to latest checkpoint"
     )
     parser.add_argument("--seed", type=int, default=42)
-    boolean_flag(parser, "verbose", default=False)
-    boolean_flag(parser, "check", default=False)
+    boolean_flag(parser, "verbose", default=None)
+    boolean_flag(parser, "check", default=None)
     boolean_flag(
         parser, "deterministic",
         default=None,
@@ -82,7 +84,8 @@ def main(args, unknown_args):
         dump_environment(config, experiment.logdir, args.configs)
         dump_code(args.expdir, experiment.logdir)
 
-    runner.run_experiment(experiment, check=args.check)
+    check_run = safitty.get(config, "args", "check", default=False)
+    runner.run_experiment(experiment, check=check_run)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Currently `verbose` and `check` arguments are ignored in Config API if set in config files because of presence of default values in args parser. Default value in args parser for `verbose` isn't necessary as we're check it later in [`ConfigExperiment#__init__`](https://github.com/catalyst-team/catalyst/blob/master/catalyst/dl/experiment/config.py#L46).

I've added similar check for `check` argument to be able use config files with this parameter.

## Type of Change

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [x] I have checked the code-style using `make check-style`.
- [x] I have written the docstring in Google format for all the methods and classes that I used.
- [x] I have checked the docs using `make check-docs`.