### PR TITLE
Fix bug in tensorflow versions comparison 

### DIFF
--- a/catalyst/utils/seed.py
+++ b/catalyst/utils/seed.py
@@ -1,6 +1,7 @@
 import random
 
 import numpy as np
+from packaging.version import Version, parse
 
 
 def set_global_seed(seed: int) -> None:
@@ -22,9 +23,9 @@ def set_global_seed(seed: int) -> None:
     except ImportError:
         pass
     else:
-        if tf.__version__ >= "2.0.0":
+        if parse(tf.__version__) >= Version("2.0.0"):
             tf.random.set_seed(seed)
-        elif tf.__version__ <= "1.13.2":
+        elif parse(tf.__version__) <= Version("1.13.2"):
             tf.set_random_seed(seed)
         else:
             tf.compat.v1.set_random_seed(seed)

--- a/catalyst/utils/seed.py
+++ b/catalyst/utils/seed.py
@@ -1,7 +1,7 @@
 import random
 
 import numpy as np
-from packaging.version import Version, parse
+from packaging.version import parse, Version
 
 
 def set_global_seed(seed: int) -> None:


### PR DESCRIPTION
before fix '1.4.1' >= '1.13.2' and tf.compat.v1.set_random_seed(seed)
failed because v1 doen't exists

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [x] I have checked the code-style using `make check-style`.
- [x] I have written the docstring in Google format for all the methods and classes that I used.
- [x] I have checked the docs using `make check-docs`.