### PR TITLE
Docs updates for NLP example & verbose flag

### DIFF
--- a/examples/distilbert_text_classification/README.md
+++ b/examples/distilbert_text_classification/README.md
@@ -1,12 +1,12 @@
 ## Transformers for sequence classification
 
 ### Prerequisites
-`pip install catalyst[nlp]`
+`pip install -U catalyst[nlp]`
 
 ### Running text classification experiment with DistilBert
 1. Specify path to data and train/validation file names in `config.yaml`. For instance, you can [download](https://www.kaggle.com/c/amazon-pet-product-reviews-classification/data) Amazon pet product reviews and put training and validation files into the `input` folder
 2. Specify text and label columns to read. By default, these are `text` for text field and `label` for targets
-3. From the `examples` folder, run `catalyst-dl run -C distilbert_text_classification/config.yml`
-4. When training is done, you'll find logs, configs and model checkpoints in the `logs` folder (this path is also configurable)  
+3. From the `examples` folder, run `catalyst-dl run -C distilbert_text_classification/config.yml --verbose`
+4. When training is done, you'll find logs, configs and model checkpoints in the `logs` folder (this path is also configurable)
 
-Same with Jupyter API - [tutorial](https://www.kaggle.com/kashnitsky/distillbert-catalyst-amazon-product-reviews)
+Same with Notebook API - [tutorial](https://www.kaggle.com/kashnitsky/distillbert-catalyst-amazon-product-reviews)


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
- Added `verbose` flag because it is an example and users would like to see the training process.
- Change `Jupyter API` to `Notebook API`

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->
N/A

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [x] I have checked the code-style using `make check-style`.
- [x] I have written the docstring in Google format for all the methods and classes that I used.
- [x] I have checked the docs using `make check-docs`.