### PR TITLE
Fix bug in ppv_tpr_f1_meter

### DIFF
--- a/catalyst/dl/meters/ppv_tpr_f1_meter.py
+++ b/catalyst/dl/meters/ppv_tpr_f1_meter.py
@@ -87,6 +87,7 @@ class PrecisionRecallF1ScoreMeter(meter.Meter):
             target = target.cpu().squeeze().numpy()
         elif isinstance(target, numbers.Number):
             target = np.asarray([target])
+        target = np.int32(target)
         assert output.size == target.size, \
             "outputs and targets must have the same number of elements"
         assert np.all(np.add(np.equal(target, 1), np.equal(target, 0))), \


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

Fix bug in ppv_tpr_f1_meter.py
Crashes when a target has float type.

```
  File "/home/awecom/anaconda3/envs/workframe/lib/python3.6/site-packages/catalyst/dl/core/callback.py", line 214, in on_batch_end
    self.meters[i].add(probabilities[:, i], targets[:, i])
  File "/home/awecom/anaconda3/envs/workframe/lib/python3.6/site-packages/catalyst/dl/meters/ppv_tpr_f1_meter.py", line 93, in add
    "targets should be binary (0, 1)"
AssertionError: targets should be binary (0, 1)
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [ ] I have checked the code-style using `make check-style`.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.