### PR TITLE
fix `AttributeError: 'PosixPath' object has no attribute 'endswith'`

### DIFF
--- a/catalyst/utils/image.py
+++ b/catalyst/utils/image.py
@@ -59,12 +59,11 @@ def imread(
     Returns:
 
     """
+    uri = str(uri)
+
     if rootpath is not None:
-        uri = str(uri)
         rootpath = str(rootpath)
-        uri = str(
-            uri if uri.startswith(rootpath) else os.path.join(rootpath, uri)
-        )
+        uri = uri if uri.startswith(rootpath) else os.path.join(rootpath, uri)
 
     if JPEG4PY_ENABLED and uri.endswith(("jpg", "JPG", "jpeg", "JPEG")):
         img = jpeg.JPEG(uri).decode()


### PR DESCRIPTION
fix `AttributeError: 'PosixPath' object has no attribute 'endswith'` in case JPEG4PY_ENABLED=True and uri is `pathlib.Path`

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [ ] I have checked the code-style using `make check-style`.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.