### PR TITLE
logger not set ConsoleLogger, TensorboardLogger error

### DIFF
--- a/catalyst/dl/callbacks/logging.py
+++ b/catalyst/dl/callbacks/logging.py
@@ -112,8 +112,6 @@ class ConsoleLogger(LoggerCallback):
         logger = logging.getLogger("metrics_logger")
         logger.setLevel(logging.INFO)
 
-        fh = logging.FileHandler(f"{logdir}/log.txt")
-        fh.setLevel(logging.INFO)
         ch = logging.StreamHandler(sys.stdout)
         ch.setLevel(logging.INFO)
         # @TODO: fix json logger
@@ -122,29 +120,29 @@ class ConsoleLogger(LoggerCallback):
 
         txt_formatter = TxtMetricsFormatter()
         # json_formatter = JsonMetricsFormatter()
-        fh.setFormatter(txt_formatter)
         ch.setFormatter(txt_formatter)
         # jh.setFormatter(json_formatter)
 
         # add the handlers to the logger
-        logger.addHandler(fh)
         logger.addHandler(ch)
+
+        if logdir:
+            fh = logging.FileHandler(f"{logdir}/log.txt")
+            fh.setLevel(logging.INFO)
+            fh.setFormatter(txt_formatter)
+            logger.addHandler(fh)
+
         # logger.addHandler(jh)
         return logger
 
     def on_stage_start(self, state: RunnerState):
         """Prepare ``state.logdir`` for the current stage"""
-        if state.logdir is None:
-            return
-
-        state.logdir.mkdir(parents=True, exist_ok=True)
+        if state.logdir:
+            state.logdir.mkdir(parents=True, exist_ok=True)
         self.logger = self._get_logger(state.logdir)
 
     def on_stage_end(self, state):
         """Called at the end of each stage"""
-        if state.logdir is None:
-            return
-
         for handler in self.logger.handlers:
             handler.close()
         self.logger.handlers = []
@@ -154,9 +152,6 @@ class ConsoleLogger(LoggerCallback):
         Translate ``state.metrics`` to console and text file
         at the end of an epoch
         """
-        if state.logdir is None:
-            return
-
         self.logger.info("", extra={"state": state})
 
 

--- a/catalyst/dl/callbacks/logging.py
+++ b/catalyst/dl/callbacks/logging.py
@@ -134,12 +134,17 @@ class ConsoleLogger(LoggerCallback):
 
     def on_stage_start(self, state: RunnerState):
         """Prepare ``state.logdir`` for the current stage"""
-        assert state.logdir is not None
+        if state.logdir is None:
+            return
+
         state.logdir.mkdir(parents=True, exist_ok=True)
         self.logger = self._get_logger(state.logdir)
 
     def on_stage_end(self, state):
         """Called at the end of each stage"""
+        if state.logdir is None:
+            return
+
         for handler in self.logger.handlers:
             handler.close()
         self.logger.handlers = []
@@ -149,6 +154,9 @@ class ConsoleLogger(LoggerCallback):
         Translate ``state.metrics`` to console and text file
         at the end of an epoch
         """
+        if state.logdir is None:
+            return
+
         self.logger.info("", extra={"state": state})
 
 
@@ -196,6 +204,9 @@ class TensorboardLogger(LoggerCallback):
 
     def on_loader_start(self, state):
         """Prepare tensorboard writers for the current stage"""
+        if state.logdir is None:
+            return
+
         lm = state.loader_name
         if lm not in self.loggers:
             log_dir = os.path.join(state.logdir, f"{lm}_log")
@@ -203,6 +214,9 @@ class TensorboardLogger(LoggerCallback):
 
     def on_batch_end(self, state: RunnerState):
         """Translate batch metrics to tensorboard"""
+        if state.logdir is None:
+            return
+
         if self.log_on_batch_end:
             mode = state.loader_name
             metrics_ = state.metrics.batch_values
@@ -212,6 +226,9 @@ class TensorboardLogger(LoggerCallback):
 
     def on_loader_end(self, state: RunnerState):
         """Translate epoch metrics to tensorboard"""
+        if state.logdir is None:
+            return
+
         if self.log_on_epoch_end:
             mode = state.loader_name
             metrics_ = state.metrics.epoch_values[mode]
@@ -226,6 +243,9 @@ class TensorboardLogger(LoggerCallback):
 
     def on_stage_end(self, state: RunnerState):
         """Close opened tensorboard writers"""
+        if state.logdir is None:
+            return
+
         for logger in self.loggers.values():
             logger.close()
 


### PR DESCRIPTION
## Description
Suppose, logdir is not set when. Then the library crashes with the error:

```
  File "/home/ingenix/anaconda/bin/catalyst-dl", line 11, in <module>
    load_entry_point('catalyst==19.12', 'console_scripts', 'catalyst-dl')()
  File "/home/ingenix/anaconda/lib/python3.7/site-packages/catalyst/dl/__main__.py", line 44, in main
    COMMANDS[args.command].main(args, uargs)
  File "/home/ingenix/anaconda/lib/python3.7/site-packages/catalyst/dl/scripts/run.py", line 89, in main
    runner.run_experiment(experiment, check=check_run)
  File "/home/ingenix/anaconda/lib/python3.7/site-packages/catalyst/dl/core/runner.py", line 352, in run_experiment
    self._run_event("exception", moment=None)
  File "/home/ingenix/anaconda/lib/python3.7/site-packages/catalyst/dl/core/runner.py", line 123, in _run_event
    getattr(logger, fn_name)(self.state)
  File "/home/ingenix/anaconda/lib/python3.7/site-packages/catalyst/dl/callbacks/misc.py", line 155, in on_exception
    raise exception
  File "/home/ingenix/anaconda/lib/python3.7/site-packages/catalyst/dl/core/runner.py", line 349, in run_experiment
    self._run_stage(stage)
  File "/home/ingenix/anaconda/lib/python3.7/site-packages/catalyst/dl/core/runner.py", line 314, in _run_stage
    self._run_event("stage", moment="start")
  File "/home/ingenix/anaconda/lib/python3.7/site-packages/catalyst/dl/core/runner.py", line 112, in _run_event
    getattr(logger, fn_name)(self.state)
  File "/home/ingenix/anaconda/lib/python3.7/site-packages/catalyst/dl/callbacks/logging.py", line 137, in on_stage_start
    assert state.logdir is not None
AssertionError
```

We need to remove the writing on the disk if logdir is not set.

## Type of Change

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [x] I have checked the code-style using `make check-style`.
- [x] I have written the docstring in Google format for all the methods and classes that I used.
- [x] I have checked the docs using `make check-docs`.