### PR TITLE
fix bug with passing arguments to criterion callbacks in key-value fo…

### DIFF
--- a/catalyst/dl/callbacks/criterion.py
+++ b/catalyst/dl/callbacks/criterion.py
@@ -65,29 +65,12 @@ class CriterionCallback(Callback):
 
         self._get_input = utils.get_dictkey_auto_fn(self.input_key)
         self._get_output = utils.get_dictkey_auto_fn(self.output_key)
-        kv_types = (dict, tuple, list, type(None))
-        # @TODO: fix to only KV usage
-        if isinstance(self.input_key, str) \
-                and isinstance(self.output_key, str):
-            self._compute_loss = self._compute_loss_value
-        elif isinstance(self.input_key, kv_types) \
-                and isinstance(self.output_key, kv_types):
-            self._compute_loss = self._compute_loss_key_value
-        else:
-            raise NotImplementedError()
 
-    def _compute_loss_value(self, state: RunnerState, criterion):
+    def _compute_loss(self, state: RunnerState, criterion):
         output = self._get_output(state.output, self.output_key)
         input = self._get_input(state.input, self.input_key)
 
         loss = criterion(output, input)
-        return loss
-
-    def _compute_loss_key_value(self, state: RunnerState, criterion):
-        output = self._get_output(state.output, self.output_key)
-        input = self._get_input(state.input, self.input_key)
-
-        loss = criterion(**output, **input)
         return loss
 
     def on_stage_start(self, state: RunnerState):


### PR DESCRIPTION
…rmat

## Description

When i use loss like this
```
loss_wh:
  callback: CriterionCallback
  input_key: null
  output_key: null
  prefix: loss_wh
  criterion_key: l1_wh
  multiplier: *wh_weight
```
In dl/callbacks/criterion.py method _compute_loss_key_value fails
```
def _compute_loss_key_value(self, state: RunnerState, criterion):
        output = self._get_output(state.output, self.output_key)
        input = self._get_input(state.input, self.input_key)
        loss = criterion(**output, **input)
        return loss
```
Because there are same keys in ```**input``` and ```**output```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [ ] I have checked the code-style using `make check-style`.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [x] I have checked the docs using `make check-docs`.