### PR TITLE
fix second level of `_key_value` logic in `transform_params`

### DIFF
--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -332,7 +332,7 @@ class ConfigExperiment(Experiment):
                 for key, params_ in params.items()
             }
 
-            transform = {
+            transform = AugmentorCompose({
                 key: Augmentor(
                     dict_key=key,
                     augment_fn=transform,
@@ -340,7 +340,7 @@ class ConfigExperiment(Experiment):
                     output_key=key,
                 )
                 for key, transform in transforms_composition.items()
-            }
+            })
         else:
             if "transforms" in params:
                 transforms_composition = [

--- a/examples/_tests_mnist_stages2/config_finder.yml
+++ b/examples/_tests_mnist_stages2/config_finder.yml
@@ -15,27 +15,13 @@ stages:
     num_workers: 0
 
   transform_params:
-    _key_value: True
-
-    train: &transform
-      _key_value: True
-
-      image:
-        transform: Compose
-        transforms:
-          - transform: TensorToImage
-          - transform: Normalize
-            mean: [0.1307]
-            std: [0.3081]
-          - transform: ToTensor
-    valid:
-      transform: Compose
-      transforms:
-        - transform: TensorToImage
-        - transform: Normalize
-          mean: [0.1307]
-          std: [0.3081]
-        - transform: ToTensor
+    transform: Compose
+    transforms:
+      - transform: TensorToImage
+      - transform: Normalize
+        mean: [0.1307]
+        std: [0.3081]
+      - transform: ToTensor
 
   criterion_params:
       criterion: CrossEntropyLoss

--- a/examples/_tests_mnist_stages2/config_fp16_O1.yml
+++ b/examples/_tests_mnist_stages2/config_fp16_O1.yml
@@ -24,23 +24,22 @@ stages:
     train:
       _key_value: True
 
-      transform: Compose
-      transforms:
-        - transform: TensorToImage
-        - transform: Normalize
-          mean: [0.1307]
-          std: [0.3081]
-        - transform: ToTensorV2
+      image:
+        transform: Compose
+        transforms:
+          - transform: TensorToImage
+          - transform: Normalize
+            mean: [0.1307]
+            std: [0.3081]
+          - transform: ToTensor
     valid:
-      _key_value: True
-
       transform: Compose
       transforms:
         - transform: TensorToImage
         - transform: Normalize
           mean: [0.1307]
           std: [0.3081]
-        - transform: ToTensorV2
+        - transform: ToTensor
 
   state_params:
     main_metric: &reduce_metric accuracy01

--- a/examples/_tests_mnist_stages2/config_fp16_O2.yml
+++ b/examples/_tests_mnist_stages2/config_fp16_O2.yml
@@ -18,13 +18,30 @@ stages:
     num_workers: 0
 
   transform_params:
-    transform: Compose
-    transforms:
-      - transform: TensorToImage
-      - transform: Normalize
-        mean: [0.1307]
-        std: [0.3081]
-      - transform: ToTensor
+    _key_value: True
+
+    train:
+      _key_value: True
+
+      image:
+        transform: Compose
+        transforms:
+          - transform: TensorToImage
+          - transform: Normalize
+            mean: [0.1307]
+            std: [0.3081]
+          - transform: ToTensor
+    valid:
+      _key_value: True
+
+      image:
+        transform: Compose
+        transforms:
+          - transform: TensorToImage
+          - transform: Normalize
+            mean: [0.1307]
+            std: [0.3081]
+          - transform: ToTensor
 
   state_params:
     main_metric: &reduce_metric accuracy01

--- a/examples/configs/config-description-eng.yml
+++ b/examples/configs/config-description-eng.yml
@@ -68,6 +68,31 @@ stages:  # REQUIRED KEYWORD, dictionary of all stages of Catalyst, for training 
     key_for_data: value  # Example
 
 
+  transform_params:
+
+    _key_value: True  # KEYWORD, if True, for each dataset (e.g. train/valid/infer) its own transforms can be defined and then they should be wrapped in key-value
+    train:  # only for train dataset
+      _key_value: False  # KEYWORD, if False, transform will be applied to the dataset sample
+
+      transform: Compose  # KEYWORD, name of the transform
+      # At this level, the parameters for __init__ of a transform can be found, for example
+      transforms:  # KEYWORD, list of transforms (should be wrapped in key-value-value) that will be passed to transform as a parameter
+        - transform: SomeTransform  # Example
+          param1: value1  # Example
+          param2: value2  # Example
+
+    valid: &transform  # only for valid dataset
+      _key_value: True  # KEYWORD, if True, for each key-value of data-sample its own transforms can be defined and then they should be wrapped in key-value-value
+
+      image:
+        transform: Compose
+        transforms:
+          - transform: SomeTransform
+            param: value
+
+    infer: *transform  # only for infer dataset
+
+
   state_params:  # REQUIRED KEYWORD, parameters for RunnerState (for all stages)
     main_metric: &main_metric accuracy01  # REQUIRED KEYWORD, the name of the metric by which the checkpoints will be taken
     minimize_metric: False  # REQUIRED KEYWORD, flag, should we minimize `main_metric`

--- a/examples/configs/config-description-rus.yml
+++ b/examples/configs/config-description-rus.yml
@@ -68,6 +68,31 @@ stages:  # REQUIRED KEYWORD, словарь всех стадий Catalyst, дл
     key_for_data: value  # Пример
 
 
+  transform_params:
+    _key_value: True  # KEYWORD, если True, то для каждого датасета (e.g. train/valid/infer) можно определить свои трансформации и тогда их нужно обернуть еще в key-value
+
+    train:  # трансформация только для train датасета
+      _key_value: False  # KEYWORD, если False, то трансформация будет применяться сразу ко всему data-sample
+
+      transform: Compose  # KEYWORD, имя трансформации
+      # на этом уровне могут лежать параметры для __init__ данного transform, например
+      transforms:  # KEYWORD, список трансформаций (нужно обернуть еще в key-value) который будет передан как параметр
+        - transform: SomeTransform  # Пример
+          param1: value1  # Пример
+          param2: value2  # Пример
+
+    valid: &transform  # трансформация только для valid датасета
+      _key_value: True  # KEYWORD, если True, то для каждого key-value в data-sample можно определить свои трансформации и тогда их нужно обернуть еще в key-value, note: трансформации будут применяться отдельно для каждого key-value в data-sample
+
+      image:
+        transform: Compose
+        transforms:
+          - transform: SomeTransform
+            param: value
+
+    infer: *transform  # трансформация только для infer датасета
+
+
   state_params:  # REQUIRED KEYWORD, параметры для RunnerState (для всех стейджей)
     main_metric: &main_metric accuracy01  # REQUIRED KEYWORD, имя метрики, по которой будут отбираться чекпоинты
     minimize_metric: False  # REQUIRED KEYWORD, флаг, нужно ли минимизировать `main_metric`


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [x] I have read I need to click 'Login as guest' to see Teamcity build logs
- [x] I have checked the code-style using `make check-style`.
- [x] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.