### PR TITLE
Minor fix in SupervisedNeptuneRunner docstrings

### DIFF
--- a/catalyst/contrib/dl/runner/neptune.py
+++ b/catalyst/contrib/dl/runner/neptune.py
@@ -12,12 +12,12 @@ from catalyst.dl.runner import SupervisedRunner
 class NeptuneRunner(Runner):
     """
     Runner wrapper with Neptune integration hooks.
-    Read about Neptune here https://neptune.ml
+    Read about Neptune here https://neptune.ai
 
     Examples:
         Initialize runner::
 
-            from catalyst.contrib.runner.neptune import SupervisedNeptuneRunner
+            from catalyst.contrib.dl.runner.neptune import SupervisedNeptuneRunner
             runner = SupervisedNeptuneRunner()
 
         Pass `monitoring_params` and train model::
@@ -32,8 +32,8 @@ class NeptuneRunner(Runner):
                 verbose=True,
                 monitoring_params={
                     "init": {
-                    "project_qualified_name": "hapyp-user/examples",
-                    "api_token": None, # api key, keep in NEPTUNE_API_TOKEN
+                    "project_qualified_name": "neptune-ai/catalyst",
+                    "api_token": os.getenv('NEPTUNE_API_TOKEN'), # api key, keep in NEPTUNE_API_TOKEN
                 },
                     "create_experiment": {
                         "name": "catalyst-example", # experiment name


### PR DESCRIPTION
## Description

* minor fix in example section of docstrings (import structure has changed I think), 
* changed neptune.ml -> neptune.ai as we switched domains


## Type of Change

- [x] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [x] I have read I need to click 'Login as guest' to see Teamcity build logs
- [x] I have checked the code-style using `make check-codestyle`.
- [x] I have written the docstring in Google format for all the methods and classes that I used.
- [x] I have checked the docs using `make check-docs`.