### PR TITLE
add processing configs with dependencies

### DIFF
--- a/catalyst/utils/config.py
+++ b/catalyst/utils/config.py
@@ -1,22 +1,25 @@
+from collections import OrderedDict
 import copy
+from itertools import chain
 import json
+from logging import getLogger
 import os
+from pathlib import Path
 import platform
 import re
 import shutil
 import subprocess
 import sys
-from collections import OrderedDict
-from itertools import chain
-from logging import getLogger
-from pathlib import Path
-from typing import Any, Dict, List, Union  # isort:skip
 
 import safitty
 import yaml
 
 from catalyst import utils
 from catalyst.utils.tools.tensorboard import SummaryWriter
+
+from typing import Any, Dict, List, Union  # isort:skip
+
+
 
 LOG = getLogger(__name__)
 

--- a/catalyst/utils/config.py
+++ b/catalyst/utils/config.py
@@ -260,23 +260,22 @@ def parse_config_args(*, config, args, unknown_args):
 
 def get_recursive_configs(config_path):
     configs = []
-    with open(config_path, "r") as fin:
-        config_ = safitty.load(config_path)
-        base_dir = os.path.dirname(config_path)
+    config_ = safitty.load(config_path)
+    base_dir = os.path.dirname(config_path)
 
-        if 'pre_configs' in config_:
-            pre_configs = config_['pre_configs']
-            for pre_config in pre_configs:
-                pre_config = os.path.join(base_dir, pre_config)
-                configs += get_recursive_configs(pre_config)
+    if 'pre_configs' in config_:
+        pre_configs = config_['pre_configs']
+        for pre_config in pre_configs:
+            pre_config = os.path.join(base_dir, pre_config)
+            configs += get_recursive_configs(pre_config)
 
-        configs += [config_path]
+    configs += [config_path]
 
-        if 'post_configs' in config_:
-            post_configs = config_['post_configs']
-            for post_config in post_configs:
-                post_config = os.path.join(base_dir, post_config)
-                configs += [get_recursive_configs(post_config)]
+    if 'post_configs' in config_:
+        post_configs = config_['post_configs']
+        for post_config in post_configs:
+            post_config = os.path.join(base_dir, post_config)
+            configs += [get_recursive_configs(post_config)]
 
     return configs
 

--- a/catalyst/utils/config.py
+++ b/catalyst/utils/config.py
@@ -19,8 +19,6 @@ from catalyst.utils.tools.tensorboard import SummaryWriter
 
 from typing import Any, Dict, List, Union  # isort:skip
 
-
-
 LOG = getLogger(__name__)
 
 
@@ -306,7 +304,9 @@ def parse_args_uargs(args, unknown_args):
         tuple: updated arguments, dict with config
     """
     args_ = copy.deepcopy(args)
-    args_.configs = [get_recursive_configs(config_path) for config_path in args_.configs]
+    args_.configs = [
+        get_recursive_configs(config_path) for config_path in args_.configs
+    ]
     args_.configs = list(chain(*args_.configs))
 
     # load params

--- a/catalyst/utils/config.py
+++ b/catalyst/utils/config.py
@@ -263,16 +263,16 @@ def get_recursive_configs(config_path):
     config_ = safitty.load(config_path)
     base_dir = os.path.dirname(config_path)
 
-    if 'pre_configs' in config_:
-        pre_configs = config_['pre_configs']
+    if "pre_configs" in config_:
+        pre_configs = config_["pre_configs"]
         for pre_config in pre_configs:
             pre_config = os.path.join(base_dir, pre_config)
             configs += get_recursive_configs(pre_config)
 
     configs += [config_path]
 
-    if 'post_configs' in config_:
-        post_configs = config_['post_configs']
+    if "post_configs" in config_:
+        post_configs = config_["post_configs"]
         for post_config in post_configs:
             post_config = os.path.join(base_dir, post_config)
             configs += [get_recursive_configs(post_config)]

--- a/catalyst/utils/config.py
+++ b/catalyst/utils/config.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 import copy
 from itertools import chain
 import json
-from logging import getLogger
+import logging
 import os
 from pathlib import Path
 import platform
@@ -10,6 +10,7 @@ import re
 import shutil
 import subprocess
 import sys
+from typing import Any, Dict, List, Union
 
 import safitty
 import yaml
@@ -17,9 +18,7 @@ import yaml
 from catalyst import utils
 from catalyst.utils.tools.tensorboard import SummaryWriter
 
-from typing import Any, Dict, List, Union  # isort:skip
-
-LOG = getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def load_ordered_yaml(
@@ -259,20 +258,10 @@ def parse_config_args(*, config, args, unknown_args):
     return config, args
 
 
-def load_config(fin, config_path):
-    if config_path.endswith("json"):
-        config_ = json.load(fin, object_pairs_hook=OrderedDict)
-    elif config_path.endswith("yml"):
-        config_ = load_ordered_yaml(fin)
-    else:
-        raise Exception("Unknown file format")
-    return config_
-
-
 def get_recursive_configs(config_path):
     configs = []
     with open(config_path, "r") as fin:
-        config_ = load_config(fin, config_path)
+        config_ = safitty.load(config_path)
         base_dir = os.path.dirname(config_path)
 
         if 'pre_configs' in config_:
@@ -312,8 +301,7 @@ def parse_args_uargs(args, unknown_args):
     # load params
     config = {}
     for config_path in args_.configs:
-        with open(config_path, "r") as fin:
-            config_ = load_config(fin, config_path)
+        config_ = safitty.load(config_path)
         config = utils.merge_dicts(config, config_)
 
     config, args_ = parse_config_args(

--- a/catalyst/utils/config.py
+++ b/catalyst/utils/config.py
@@ -1,15 +1,16 @@
-from typing import Any, Dict, List, Union  # isort:skip
-from collections import OrderedDict
 import copy
 import json
-from logging import getLogger
 import os
-from pathlib import Path
 import platform
 import re
 import shutil
 import subprocess
 import sys
+from collections import OrderedDict
+from itertools import chain
+from logging import getLogger
+from pathlib import Path
+from typing import Any, Dict, List, Union  # isort:skip
 
 import safitty
 import yaml
@@ -257,6 +258,39 @@ def parse_config_args(*, config, args, unknown_args):
     return config, args
 
 
+def load_config(fin, config_path):
+    if config_path.endswith("json"):
+        config_ = json.load(fin, object_pairs_hook=OrderedDict)
+    elif config_path.endswith("yml"):
+        config_ = load_ordered_yaml(fin)
+    else:
+        raise Exception("Unknown file format")
+    return config_
+
+
+def get_recursive_configs(config_path):
+    configs = []
+    with open(config_path, "r") as fin:
+        config_ = load_config(fin, config_path)
+        base_dir = os.path.dirname(config_path)
+
+        if 'pre_configs' in config_:
+            pre_configs = config_['pre_configs']
+            for pre_config in pre_configs:
+                pre_config = os.path.join(base_dir, pre_config)
+                configs += get_recursive_configs(pre_config)
+
+        configs += [config_path]
+
+        if 'post_configs' in config_:
+            post_configs = config_['post_configs']
+            for post_config in post_configs:
+                post_config = os.path.join(base_dir, post_config)
+                configs += [get_recursive_configs(post_config)]
+
+    return configs
+
+
 def parse_args_uargs(args, unknown_args):
     """
     Function for parsing configuration files
@@ -269,17 +303,14 @@ def parse_args_uargs(args, unknown_args):
         tuple: updated arguments, dict with config
     """
     args_ = copy.deepcopy(args)
+    args_.configs = [get_recursive_configs(config_path) for config_path in args_.configs]
+    args_.configs = list(chain(*args_.configs))
 
     # load params
     config = {}
     for config_path in args_.configs:
         with open(config_path, "r") as fin:
-            if config_path.endswith("json"):
-                config_ = json.load(fin, object_pairs_hook=OrderedDict)
-            elif config_path.endswith("yml"):
-                config_ = load_ordered_yaml(fin)
-            else:
-                raise Exception("Unknown file format")
+            config_ = load_config(fin, config_path)
         config = utils.merge_dicts(config, config_)
 
     config, args_ = parse_config_args(


### PR DESCRIPTION
## Description
Lets  `main.yml` has fields:
```
pre_configs: ['pre1.yml', 'pre2.yml']
post_configs: ['post1.yml', 'post2.yml']
```
Now command `catalyst-dl run -C main.yml` has the same effect as command
`catalyst-dl run -C pre1.yml pre2.yml main.yml post1.yml post2.yml` 
in previous version

close #624 
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [x] I have read I need to click 'Login as guest' to see Teamcity build logs
- [x] I have checked the code-style using `make check-codestyle`.
- [x] I have written the docstring in Google format for all the methods and classes that I used.
- [x] I have checked the docs using `make check-docs`.