### PR TITLE
Easy distributed data parallel mode

### DIFF
--- a/catalyst/core/callbacks/checkpoint.py
+++ b/catalyst/core/callbacks/checkpoint.py
@@ -138,8 +138,10 @@ class CheckpointCallback(BaseCheckpointCallback):
         ]
         best_valid_metrics = top_best_checkpoints[0][1]
         metrics = OrderedDict(
-            [("best", best_valid_metrics)] + [("last", last_valid_metrics)] +
-            top_best_checkpoints + all_epochs_metrics
+            [("best", best_valid_metrics)] +
+            [("last", last_valid_metrics)] +
+            top_best_checkpoints +
+            all_epochs_metrics
         )
 
         self.metrics = metrics
@@ -155,8 +157,7 @@ class CheckpointCallback(BaseCheckpointCallback):
             last_item = self.top_best_metrics.pop(-1)
             last_filepath = Path(last_item[0])
             last_filepaths = last_filepath.parent.glob(
-                last_filepath.name.replace(".pth", "*")
-            )
+                last_filepath.name.replace(".pth", "*"))
             for filepath in last_filepaths:
                 os.remove(filepath)
 
@@ -295,7 +296,10 @@ class IterationCheckpointCallback(BaseCheckpointCallback):
             for (order_index, valid_metric) in enumerate(self.epochs_metrics)
         ]
 
-        metrics = OrderedDict(n_last_checkpoints + all_epochs_metrics)
+        metrics = OrderedDict(
+            n_last_checkpoints +
+            all_epochs_metrics
+        )
         self.metrics = metrics
         return self.metrics
 
@@ -306,7 +310,10 @@ class IterationCheckpointCallback(BaseCheckpointCallback):
             os.remove(top_filepath)
 
     def process_checkpoint(
-        self, logdir: str, checkpoint: Dict, batch_values: Dict[str, float]
+        self,
+        logdir: str,
+        checkpoint: Dict,
+        batch_values: Dict[str, float]
     ):
         filepath = utils.save_checkpoint(
             logdir=Path(f"{logdir}/checkpoints/"),

--- a/catalyst/core/callbacks/checkpoint.py
+++ b/catalyst/core/callbacks/checkpoint.py
@@ -7,6 +7,7 @@ import safitty
 
 from catalyst import utils
 from catalyst.core import _State, Callback, CallbackOrder
+from catalyst.utils import get_rank
 
 
 class BaseCheckpointCallback(Callback):
@@ -214,7 +215,7 @@ class CheckpointCallback(BaseCheckpointCallback):
             self.load_checkpoint(filename=self.resume, state=state)
 
     def on_epoch_end(self, state: _State):
-        if state.stage.startswith("infer"):
+        if state.stage.startswith("infer") or get_rank() > 0:
             return
 
         valid_metrics = dict(state.metric_manager.valid_values)

--- a/catalyst/core/callbacks/checkpoint.py
+++ b/catalyst/core/callbacks/checkpoint.py
@@ -138,10 +138,8 @@ class CheckpointCallback(BaseCheckpointCallback):
         ]
         best_valid_metrics = top_best_checkpoints[0][1]
         metrics = OrderedDict(
-            [("best", best_valid_metrics)] +
-            [("last", last_valid_metrics)] +
-            top_best_checkpoints +
-            all_epochs_metrics
+            [("best", best_valid_metrics)] + [("last", last_valid_metrics)] +
+            top_best_checkpoints + all_epochs_metrics
         )
 
         self.metrics = metrics
@@ -157,7 +155,8 @@ class CheckpointCallback(BaseCheckpointCallback):
             last_item = self.top_best_metrics.pop(-1)
             last_filepath = Path(last_item[0])
             last_filepaths = last_filepath.parent.glob(
-                last_filepath.name.replace(".pth", "*"))
+                last_filepath.name.replace(".pth", "*")
+            )
             for filepath in last_filepaths:
                 os.remove(filepath)
 
@@ -296,10 +295,7 @@ class IterationCheckpointCallback(BaseCheckpointCallback):
             for (order_index, valid_metric) in enumerate(self.epochs_metrics)
         ]
 
-        metrics = OrderedDict(
-            n_last_checkpoints +
-            all_epochs_metrics
-        )
+        metrics = OrderedDict(n_last_checkpoints + all_epochs_metrics)
         self.metrics = metrics
         return self.metrics
 
@@ -310,10 +306,7 @@ class IterationCheckpointCallback(BaseCheckpointCallback):
             os.remove(top_filepath)
 
     def process_checkpoint(
-        self,
-        logdir: str,
-        checkpoint: Dict,
-        batch_values: Dict[str, float]
+        self, logdir: str, checkpoint: Dict, batch_values: Dict[str, float]
     ):
         filepath = utils.save_checkpoint(
             logdir=Path(f"{logdir}/checkpoints/"),

--- a/catalyst/data/__init__.py
+++ b/catalyst/data/__init__.py
@@ -10,5 +10,5 @@ from .reader import (
     ScalarReader
 )
 from .sampler import (
-    BalanceClassSampler, DistributedSamplerOverSampler, MiniEpochSampler
+    BalanceClassSampler, DistributedSamplerWrapper, MiniEpochSampler
 )

--- a/catalyst/data/__init__.py
+++ b/catalyst/data/__init__.py
@@ -7,4 +7,6 @@ from .reader import (
     ImageReader, LambdaReader, MaskReader, ReaderCompose, ReaderSpec,
     ScalarReader
 )
-from .sampler import BalanceClassSampler, MiniEpochSampler
+from .sampler import (
+    BalanceClassSampler, DistributedSamplerOverSampler, MiniEpochSampler
+)

--- a/catalyst/data/__init__.py
+++ b/catalyst/data/__init__.py
@@ -2,7 +2,9 @@
 
 from .augmentor import Augmentor, AugmentorCompose, AugmentorKeys
 from .collate_fn import FilteringCollateFn
-from .dataset import ListDataset, MergeDataset, NumpyDataset, PathsDataset
+from .dataset import (
+    DatasetFromSampler, ListDataset, MergeDataset, NumpyDataset, PathsDataset
+)
 from .reader import (
     ImageReader, LambdaReader, MaskReader, ReaderCompose, ReaderSpec,
     ScalarReader

--- a/catalyst/data/dataset.py
+++ b/catalyst/data/dataset.py
@@ -1,9 +1,9 @@
-from typing import Any, Callable, Dict, List, Union  # isort:skip
 from pathlib import Path
+from typing import Any, Callable, Dict, List, Union
 
 import numpy as np
 
-from torch.utils.data import Dataset
+from torch.utils.data import Dataset, Sampler
 
 from catalyst.utils import merge_dicts
 
@@ -191,4 +191,19 @@ class PathsDataset(ListDataset):
         )
 
 
-__all__ = ["ListDataset", "MergeDataset", "NumpyDataset", "PathsDataset"]
+class DatasetFromSampler(Dataset):
+    def __init__(self, sampler: Sampler):
+        self.sampler = sampler
+        self.sampler_list = None
+
+    def __getitem__(self, index: int):
+        if self.sampler_list is None:
+            self.sampler_list = list(self.sampler)
+        return self.sampler_list[index]
+
+    def __len__(self) -> int:
+        return len(self.sampler)
+
+
+__all__ = ["ListDataset", "MergeDataset", "NumpyDataset", "PathsDataset",
+           "DatasetFromSampler"]

--- a/catalyst/data/dataset.py
+++ b/catalyst/data/dataset.py
@@ -192,6 +192,9 @@ class PathsDataset(ListDataset):
 
 
 class DatasetFromSampler(Dataset):
+    """
+    Dataset of indexes from `Sampler`
+    """
     def __init__(self, sampler: Sampler):
         self.sampler = sampler
         self.sampler_list = None

--- a/catalyst/data/dataset.py
+++ b/catalyst/data/dataset.py
@@ -1,5 +1,5 @@
+from typing import Any, Callable, Dict, List, Union  # isort:skip
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Union
 
 import numpy as np
 

--- a/catalyst/data/sampler.py
+++ b/catalyst/data/sampler.py
@@ -6,7 +6,7 @@ import numpy as np
 from torch.utils.data import DistributedSampler
 from torch.utils.data.sampler import Sampler
 
-from catalyst.data.dataset import DatasetFromSampler
+from catalyst.data import DatasetFromSampler
 
 
 class BalanceClassSampler(Sampler):

--- a/catalyst/data/sampler.py
+++ b/catalyst/data/sampler.py
@@ -1,5 +1,5 @@
+from typing import Iterator, List  # isort:skip
 from operator import itemgetter
-from typing import Iterator, List
 
 import numpy as np
 

--- a/catalyst/data/sampler.py
+++ b/catalyst/data/sampler.py
@@ -159,9 +159,9 @@ class MiniEpochSampler(Sampler):
         return self.mini_epoch_len
 
 
-class DistributedSamplerOverSampler(DistributedSampler):
+class DistributedSamplerWrapper(DistributedSampler):
     def __init__(self, sampler, num_replicas=None, rank=None, shuffle=True):
-        super(DistributedSamplerOverSampler, self).__init__(
+        super(DistributedSamplerWrapper, self).__init__(
             DatasetFromSampler(sampler),
             num_replicas=num_replicas,
             rank=rank,
@@ -177,4 +177,4 @@ class DistributedSamplerOverSampler(DistributedSampler):
 
 
 __all__ = ["BalanceClassSampler", "MiniEpochSampler",
-           "DistributedSamplerOverSampler"]
+           "DistributedSamplerWrapper"]

--- a/catalyst/data/sampler.py
+++ b/catalyst/data/sampler.py
@@ -160,6 +160,26 @@ class MiniEpochSampler(Sampler):
 
 
 class DistributedSamplerWrapper(DistributedSampler):
+    """
+    Wrapper over `Sampler` for distributed training.
+    Allows you to use any sampler in distributed mode.
+
+    It is especially useful in conjunction with
+    :class:`torch.nn.parallel.DistributedDataParallel`. In such case, each
+    process can pass a DistributedSamplerWrapper instance as a DataLoader
+    sampler, and load a subset of subsampled data of the original dataset
+    that is exclusive to it.
+
+    .. note::
+        Sampler is assumed to be of constant size.
+
+    Arguments:
+        sampler: Sampler used for subsampling.
+        num_replicas (optional): Number of processes participating in
+            distributed training.
+        rank (optional): Rank of the current process within num_replicas.
+        shuffle (optional): If true (default), sampler will shuffle the indices
+    """
     def __init__(self, sampler, num_replicas=None, rank=None, shuffle=True):
         super(DistributedSamplerWrapper, self).__init__(
             DatasetFromSampler(sampler),

--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -11,6 +11,7 @@ from torch.utils.data import (  # noqa F401
 )
 
 from catalyst.data import Augmentor, AugmentorCompose
+from catalyst.data.sampler import DistributedSamplerOverSampler
 from catalyst.dl import (
     Callback, ConfusionMatrixCallback, Experiment, LoggerCallback, utils
 )
@@ -23,7 +24,7 @@ from catalyst.dl.registry import (
     CALLBACKS, CRITERIONS, MODELS, OPTIMIZERS, SAMPLERS, SCHEDULERS,
     TRANSFORMS
 )
-from catalyst.utils import DistributedSamplerOverSampler, get_rank
+from catalyst.utils import get_rank
 from catalyst.utils.tools.typing import Criterion, Model, Optimizer, Scheduler
 
 
@@ -538,7 +539,7 @@ class ConfigExperiment(Experiment):
             if not is_already_present:
                 callbacks[callback_name] = callback_fn()
 
-        # Remove LoggerCallback on slave nodes
+        # Remove LoggerCallback on workers nodes
         if get_rank() > 0:
             to_del = (LoggerCallback, ConfusionMatrixCallback)
             for k in list(

--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -545,9 +545,9 @@ class ConfigExperiment(Experiment):
         # Remove LoggerCallback on worker nodes
         if get_rank() > 0:
             to_del = (LoggerCallback, ConfusionMatrixCallback)
-            for k in filter(
+            for k in list(filter(
                     lambda c: isinstance(callbacks[c], to_del), callbacks
-            ):
+            )):
                 del callbacks[k]
 
         return callbacks

--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -463,9 +463,8 @@ class ConfigExperiment(Experiment):
             if distributed:
                 if sampler is not None:
                     if not isinstance(sampler, DistributedSampler):
-                        loader_params["sampler"] = DistributedSamplerOverSampler(
-                            sampler=sampler
-                        )
+                        loader_params["sampler"] = \
+                            DistributedSamplerOverSampler(sampler=sampler)
                 else:
                     sampler = DistributedSampler(
                         dataset=loader_params["dataset"]
@@ -544,7 +543,9 @@ class ConfigExperiment(Experiment):
         # Remove LoggerCallback on slave nodes
         if get_rank() > 0:
             to_del = (LoggerCallback, ConfusionMatrixCallback)
-            for k in list(filter(lambda c: isinstance(callbacks[c], to_del), callbacks)):
+            for k in list(
+                filter(lambda c: isinstance(callbacks[c], to_del), callbacks)
+            ):
                 del callbacks[k]
 
         return callbacks

--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -186,10 +186,7 @@ class ConfigExperiment(Experiment):
         return criterion
 
     def _get_optimizer(
-        self,
-        stage: str,
-        model: Union[Model, Dict[str, Model]],
-        **params
+        self, stage: str, model: Union[Model, Dict[str, Model]], **params
     ) -> Optimizer:
         # @TODO 1: refactoring; this method is too long
         # @TODO 2: load state dicts for schedulers & criterion
@@ -271,9 +268,7 @@ class ConfigExperiment(Experiment):
         return optimizer
 
     def get_optimizer(
-        self,
-        stage: str,
-        model: Union[Model, Dict[str, Model]]
+        self, stage: str, model: Union[Model, Dict[str, Model]]
     ) -> Union[Optimizer, Dict[str, Optimizer]]:
         """
         Returns the optimizer for a given stage
@@ -335,15 +330,17 @@ class ConfigExperiment(Experiment):
                 for key, params_ in params.items()
             }
 
-            transform = AugmentorCompose({
-                key: Augmentor(
-                    dict_key=key,
-                    augment_fn=transform,
-                    input_key=key,
-                    output_key=key,
-                )
-                for key, transform in transforms_composition.items()
-            })
+            transform = AugmentorCompose(
+                {
+                    key: Augmentor(
+                        dict_key=key,
+                        augment_fn=transform,
+                        input_key=key,
+                        output_key=key,
+                    )
+                    for key, transform in transforms_composition.items()
+                }
+            )
         else:
             if "transforms" in params:
                 transforms_composition = [
@@ -377,6 +374,7 @@ class ConfigExperiment(Experiment):
 
         transform = self._get_transform(**transform_params)
         if transform is None:
+
             def transform(dict_):
                 return dict_
         elif not isinstance(transform, AugmentorCompose):

--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -541,11 +541,11 @@ class ConfigExperiment(Experiment):
             if not is_already_present:
                 callbacks[callback_name] = callback_fn()
 
-        # Remove LoggerCallback on workers nodes
+        # Remove LoggerCallback on worker nodes
         if get_rank() > 0:
             to_del = (LoggerCallback, ConfusionMatrixCallback)
-            for k in list(
-                filter(lambda c: isinstance(callbacks[c], to_del), callbacks)
+            for k in filter(
+                    lambda c: isinstance(callbacks[c], to_del), callbacks
             ):
                 del callbacks[k]
 

--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -187,7 +187,10 @@ class ConfigExperiment(Experiment):
         return criterion
 
     def _get_optimizer(
-        self, stage: str, model: Union[Model, Dict[str, Model]], **params
+        self,
+        stage: str,
+        model: Union[Model, Dict[str, Model]],
+        **params
     ) -> Optimizer:
         # @TODO 1: refactoring; this method is too long
         # @TODO 2: load state dicts for schedulers & criterion
@@ -269,7 +272,9 @@ class ConfigExperiment(Experiment):
         return optimizer
 
     def get_optimizer(
-        self, stage: str, model: Union[Model, Dict[str, Model]]
+        self,
+        stage: str,
+        model: Union[Model, Dict[str, Model]]
     ) -> Union[Optimizer, Dict[str, Optimizer]]:
         """
         Returns the optimizer for a given stage
@@ -331,17 +336,15 @@ class ConfigExperiment(Experiment):
                 for key, params_ in params.items()
             }
 
-            transform = AugmentorCompose(
-                {
-                    key: Augmentor(
-                        dict_key=key,
-                        augment_fn=transform,
-                        input_key=key,
-                        output_key=key,
-                    )
-                    for key, transform in transforms_composition.items()
-                }
-            )
+            transform = AugmentorCompose({
+                key: Augmentor(
+                    dict_key=key,
+                    augment_fn=transform,
+                    input_key=key,
+                    output_key=key,
+                )
+                for key, transform in transforms_composition.items()
+            })
         else:
             if "transforms" in params:
                 transforms_composition = [
@@ -375,7 +378,6 @@ class ConfigExperiment(Experiment):
 
         transform = self._get_transform(**transform_params)
         if transform is None:
-
             def transform(dict_):
                 return dict_
         elif not isinstance(transform, AugmentorCompose):

--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -539,6 +539,12 @@ class ConfigExperiment(Experiment):
             if not is_already_present:
                 callbacks[callback_name] = callback_fn()
 
+        # Remove LoggerCallback on slave nodes
+        if get_rank() > 0:
+            to_del = (LoggerCallback, ConfusionMatrixCallback)
+            for k in list(filter(lambda c: isinstance(callbacks[c], to_del), callbacks)):
+                del callbacks[k]
+
         return callbacks
 
 

--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -11,7 +11,7 @@ from torch.utils.data import (  # noqa F401
 )
 
 from catalyst.data import Augmentor, AugmentorCompose
-from catalyst.data.sampler import DistributedSamplerOverSampler
+from catalyst.data.sampler import DistributedSamplerWrapper
 from catalyst.dl import (
     Callback, ConfusionMatrixCallback, Experiment, LoggerCallback, utils
 )
@@ -465,7 +465,7 @@ class ConfigExperiment(Experiment):
                 if sampler is not None:
                     if not isinstance(sampler, DistributedSampler):
                         loader_params["sampler"] = \
-                            DistributedSamplerOverSampler(sampler=sampler)
+                            DistributedSamplerWrapper(sampler=sampler)
                 else:
                     sampler = DistributedSampler(
                         dataset=loader_params["dataset"]

--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -11,7 +11,9 @@ from torch.utils.data import (  # noqa F401
 )
 
 from catalyst.data import Augmentor, AugmentorCompose
-from catalyst.dl import Callback, Experiment, utils, LoggerCallback, ConfusionMatrixCallback
+from catalyst.dl import (
+    Callback, ConfusionMatrixCallback, Experiment, LoggerCallback, utils
+)
 from catalyst.dl.callbacks import (
     CheckpointCallback, ConsoleLogger, CriterionCallback, OptimizerCallback,
     PhaseWrapperCallback, RaiseExceptionCallback, SchedulerCallback,

--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -10,8 +10,9 @@ from torch.utils.data import (  # noqa F401
     DataLoader, Dataset, DistributedSampler
 )
 
-from catalyst.data import Augmentor, AugmentorCompose
-from catalyst.data.sampler import DistributedSamplerWrapper
+from catalyst.data import (
+    Augmentor, AugmentorCompose, DistributedSamplerWrapper
+)
 from catalyst.dl import (
     Callback, ConfusionMatrixCallback, Experiment, LoggerCallback, utils
 )

--- a/catalyst/dl/scripts/run.py
+++ b/catalyst/dl/scripts/run.py
@@ -62,13 +62,14 @@ def build_args(parser: ArgumentParser):
     utils.boolean_flag(parser, "verbose", default=None)
     utils.boolean_flag(parser, "check", default=None)
     utils.boolean_flag(
-        parser,
-        "deterministic",
+        parser, "deterministic",
         default=None,
         help="Deterministic mode if running in CuDNN backend"
     )
     utils.boolean_flag(
-        parser, "benchmark", default=None, help="Use CuDNN benchmark"
+        parser, "benchmark",
+        default=None,
+        help="Use CuDNN benchmark"
     )
 
     return parser

--- a/catalyst/dl/scripts/run.py
+++ b/catalyst/dl/scripts/run.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import safitty
 
 from catalyst.dl import utils
+from catalyst.utils import get_rank, distributed_run
 
 
 def build_args(parser: ArgumentParser):
@@ -45,6 +46,17 @@ def build_args(parser: ArgumentParser):
         help="path to latest checkpoint"
     )
     parser.add_argument("--seed", type=int, default=42)
+    utils.boolean_flag(
+        parser, "apex",
+        default=True,
+        help="Enable/disable using of Apex extension"
+    )
+    utils.boolean_flag(
+        parser, "data-parallel",
+        shorthand="dp",
+        default=False,
+        help="Force using of DataParallel"
+    )
     utils.boolean_flag(parser, "verbose", default=None)
     utils.boolean_flag(parser, "check", default=None)
     utils.boolean_flag(
@@ -69,11 +81,12 @@ def parse_args():
     return args, unknown_args
 
 
-def main(args, unknown_args):
-    """Run the ``catalyst-dl run`` script"""
+def main_worker(args, unknown_args):
     args, config = utils.parse_args_uargs(args, unknown_args)
     utils.set_global_seed(args.seed)
     utils.prepare_cudnn(args.deterministic, args.benchmark)
+
+    config.setdefault('distributed_params', {})['apex'] = args.apex
 
     Experiment, Runner = utils.import_experiment_and_runner(Path(args.expdir))
 
@@ -81,12 +94,17 @@ def main(args, unknown_args):
     experiment = Experiment(config)
     runner = Runner(**runner_params)
 
-    if experiment.logdir is not None:
+    if experiment.logdir is not None and get_rank() <= 0:
         utils.dump_environment(config, experiment.logdir, args.configs)
         utils.dump_code(args.expdir, experiment.logdir)
 
     check_run = safitty.get(config, "args", "check", default=False)
     runner.run_experiment(experiment, check=check_run)
+
+
+def main(args, unknown_args):
+    """Run the ``catalyst-dl run`` script"""
+    distributed_run(args.data_parallel, main_worker, args, unknown_args)
 
 
 if __name__ == "__main__":

--- a/catalyst/dl/scripts/run.py
+++ b/catalyst/dl/scripts/run.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import safitty
 
 from catalyst.dl import utils
-from catalyst.utils import get_rank, distributed_run
+from catalyst.utils import distributed_run, get_rank
 
 
 def build_args(parser: ArgumentParser):

--- a/catalyst/dl/scripts/run.py
+++ b/catalyst/dl/scripts/run.py
@@ -47,12 +47,14 @@ def build_args(parser: ArgumentParser):
     )
     parser.add_argument("--seed", type=int, default=42)
     utils.boolean_flag(
-        parser, "apex",
+        parser,
+        "apex",
         default=True,
         help="Enable/disable using of Apex extension"
     )
     utils.boolean_flag(
-        parser, "data-parallel",
+        parser,
+        "data-parallel",
         shorthand="dp",
         default=False,
         help="Force using of DataParallel"
@@ -60,14 +62,13 @@ def build_args(parser: ArgumentParser):
     utils.boolean_flag(parser, "verbose", default=None)
     utils.boolean_flag(parser, "check", default=None)
     utils.boolean_flag(
-        parser, "deterministic",
+        parser,
+        "deterministic",
         default=None,
         help="Deterministic mode if running in CuDNN backend"
     )
     utils.boolean_flag(
-        parser, "benchmark",
-        default=None,
-        help="Use CuDNN benchmark"
+        parser, "benchmark", default=None, help="Use CuDNN benchmark"
     )
 
     return parser

--- a/catalyst/dl/scripts/run.py
+++ b/catalyst/dl/scripts/run.py
@@ -87,7 +87,7 @@ def main_worker(args, unknown_args):
     utils.set_global_seed(args.seed)
     utils.prepare_cudnn(args.deterministic, args.benchmark)
 
-    config.setdefault('distributed_params', {})['apex'] = args.apex
+    config.setdefault("distributed_params", {})["apex"] = args.apex
 
     Experiment, Runner = utils.import_experiment_and_runner(Path(args.expdir))
 

--- a/catalyst/utils/__init__.py
+++ b/catalyst/utils/__init__.py
@@ -64,10 +64,15 @@ from .serialization import deserialize, serialize
 #     SummaryWriter,
 # )
 from .torch import (
-    any2device, assert_fp16_available, ce_with_logits, detach,
+    any2device, ce_with_logits, detach,
     get_activation_fn, get_available_gpus, get_device, get_network_output,
     get_optimizable_params, get_optimizer_momentum, log1p_exp, normal_logprob,
     normal_sample, prepare_cudnn, process_model_params, set_optimizer_momentum,
-    set_requires_grad, soft_update, process_components
+    set_requires_grad, soft_update
 )
 from .visualization import plot_confusion_matrix, render_figure_to_tensor
+
+from .distributed import (
+    DistributedSamplerOverSampler, get_rank, is_apex_available,
+    process_components, assert_fp16_available, distributed_run
+)

--- a/catalyst/utils/__init__.py
+++ b/catalyst/utils/__init__.py
@@ -64,10 +64,10 @@ from .serialization import deserialize, serialize
 #     SummaryWriter,
 # )
 from .torch import (
-    any2device, ce_with_logits, detach,
-    get_activation_fn, get_available_gpus, get_device, get_network_output,
-    get_optimizable_params, get_optimizer_momentum, log1p_exp, normal_logprob,
-    normal_sample, prepare_cudnn, process_model_params, set_optimizer_momentum,
+    any2device, ce_with_logits, detach, get_activation_fn, get_available_gpus,
+    get_device, get_network_output, get_optimizable_params,
+    get_optimizer_momentum, log1p_exp, normal_logprob, normal_sample,
+    prepare_cudnn, process_model_params, set_optimizer_momentum,
     set_requires_grad, soft_update
 )
 from .visualization import plot_confusion_matrix, render_figure_to_tensor

--- a/catalyst/utils/__init__.py
+++ b/catalyst/utils/__init__.py
@@ -73,6 +73,6 @@ from .torch import (
 from .visualization import plot_confusion_matrix, render_figure_to_tensor
 
 from .distributed import (
-    DistributedSamplerOverSampler, get_rank, is_apex_available,
+    get_rank, is_apex_available, distributed_mean,
     process_components, assert_fp16_available, distributed_run
 )

--- a/catalyst/utils/distributed.py
+++ b/catalyst/utils/distributed.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 import copy
-import inspect
 import os
 import socket
 import subprocess
@@ -12,6 +11,7 @@ from torch import nn
 import torch.distributed
 
 from catalyst import utils
+from catalyst.utils.misc import get_default_params
 from catalyst.utils.tools.typing import (
     Criterion, Device, Model, Optimizer, Scheduler
 )
@@ -59,23 +59,6 @@ def distributed_mean(value: float):
         torch.distributed.all_reduce(value)
         value = float(value.item() / torch.distributed.get_world_size())
     return value
-
-
-def get_default_params(fn, exclude=None):
-    """
-
-    :param fn:
-    :param exclude:
-    :return:
-    """
-    argspec = inspect.getfullargspec(fn)
-    default_params = zip(
-        argspec.args[-len(argspec.defaults):], argspec.defaults
-    )
-    if exclude is not None:
-        default_params = filter(lambda x: x[0] not in exclude, default_params)
-    default_params = dict(default_params)
-    return default_params
 
 
 def get_slurm_params():

--- a/catalyst/utils/distributed.py
+++ b/catalyst/utils/distributed.py
@@ -1,23 +1,23 @@
+from collections import OrderedDict
 import copy
 import inspect
+from operator import itemgetter
 import os
 import socket
 import subprocess
 import sys
-from collections import OrderedDict
-from operator import itemgetter
 from typing import Dict, Tuple
 
 import torch
-import torch.distributed
 from torch import nn
+import torch.distributed
 from torch.utils.data import Dataset
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data.sampler import Sampler
 
 from catalyst import utils
 from catalyst.utils.tools.typing import (
-    Model, Criterion, Optimizer, Scheduler, Device
+    Criterion, Device, Model, Optimizer, Scheduler
 )
 
 __author__ = "Andrey Sheka"
@@ -268,9 +268,7 @@ def process_components(
     return model, criterion, optimizer, scheduler, device
 
 
-
 __all__ = [
     "DistributedSamplerOverSampler", "get_rank", "process_components",
     "is_apex_available", "assert_fp16_available", "distributed_run"
 ]
-

--- a/catalyst/utils/distributed.py
+++ b/catalyst/utils/distributed.py
@@ -71,14 +71,14 @@ def get_slurm_params():
     return cur_node_idx, num_nodes, master_node
 
 
-def is_slurm():
+def is_slurm_available():
     return "SLURM_JOB_NUM_NODES" in os.environ and "SLURM_NODEID" in os.environ
 
 
 def get_distributed_params():
     master_addr = "127.0.0.1"
     cur_node, num_nodes = 0, 1
-    if is_slurm():
+    if is_slurm_available():
         cur_node, num_nodes, master_addr = get_slurm_params()
 
     os.environ["MASTER_ADDR"] = os.getenv("MASTER_ADDR", master_addr)

--- a/catalyst/utils/distributed.py
+++ b/catalyst/utils/distributed.py
@@ -1,0 +1,276 @@
+import copy
+import inspect
+import os
+import socket
+import subprocess
+import sys
+from collections import OrderedDict
+from operator import itemgetter
+from typing import Dict, Tuple
+
+import torch
+import torch.distributed
+from torch import nn
+from torch.utils.data import Dataset
+from torch.utils.data.distributed import DistributedSampler
+from torch.utils.data.sampler import Sampler
+
+from catalyst import utils
+from catalyst.utils.tools.typing import (
+    Model, Criterion, Optimizer, Scheduler, Device
+)
+
+__author__ = "Andrey Sheka"
+__maintainer__ = "Andrey Sheka"
+__email__ = "andrey.sheka@gmail.com"
+
+
+def get_rank() -> int:
+    """
+    If torch.distributed is initialized returns ``rank``, otherwise ``-1``
+    :return:
+    """
+    if torch.distributed.is_initialized():
+        return torch.distributed.get_rank()
+    else:
+        return -1
+
+
+def is_apex_available() -> bool:
+    try:
+        import apex  # noqa: F401
+        from apex import amp  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def assert_fp16_available() -> None:
+    """
+    Asserts for installed and available Apex FP16
+    """
+    assert torch.backends.cudnn.enabled, \
+        "fp16 mode requires cudnn backend to be enabled."
+
+    assert is_apex_available(), "NVidia Apex package must be installed. "  \
+                                "See https://github.com/NVIDIA/apex."
+
+
+def distributed_mean(value: float):
+    if torch.distributed.is_initialized():
+        value = torch.tensor(value,
+                             dtype=torch.float,
+                             device=f'cuda:{torch.cuda.current_device()}',
+                             requires_grad=False)
+        torch.distributed.all_reduce(value)
+        value = float(value.item() / torch.distributed.get_world_size())
+    return value
+
+
+def get_default_params(fn, exclude=None):
+    """
+
+    :param fn:
+    :param exclude:
+    :return:
+    """
+    argspec = inspect.getfullargspec(fn)
+    default_params = zip(argspec.args[-len(argspec.defaults):], argspec.defaults)
+    if exclude is not None:
+        default_params = filter(lambda x: x[0] not in exclude, default_params)
+    default_params = dict(default_params)
+    return default_params
+
+
+def get_slurm_params():
+    cmd = "scontrol show hostnames '%s'" % os.environ['SLURM_JOB_NODELIST']
+    nodes = subprocess.getoutput(cmd).split()
+    num_nodes = int(os.environ['SLURM_JOB_NUM_NODES'])
+    current_node = os.environ['SLURMD_NODENAME']
+    master_node = socket.gethostbyname(nodes[0])
+    cur_node_idx = nodes.index(current_node)
+    return cur_node_idx, num_nodes, master_node
+
+
+def is_slurm():
+    return 'SLURM_JOB_NUM_NODES' in os.environ and 'SLURM_NODEID' in os.environ
+
+
+def get_distributed_params():
+    master_addr = '127.0.0.1'
+    cur_node, num_nodes = 0, 1
+    if is_slurm():
+        cur_node, num_nodes, master_addr = get_slurm_params()
+
+    os.environ['MASTER_ADDR'] = os.getenv('MASTER_ADDR', master_addr)
+    os.environ['MASTER_PORT'] = os.getenv('MASTER_PORT', '424242')
+
+    workers_per_node = torch.cuda.device_count()
+    start_rank = cur_node * workers_per_node
+    world_size = num_nodes * workers_per_node
+
+    local_rank = os.getenv('LOCAL_RANK', None)
+    rank = os.getenv('RANK', None)
+    local_rank, rank = [v and int(v) for v in [local_rank, rank]]
+    world_size = int(os.getenv('WORLD_SIZE', world_size))
+
+    return OrderedDict(
+        local_rank=local_rank,
+        start_rank=start_rank,
+        rank=rank,
+        world_size=world_size,
+        master_addr=os.environ['MASTER_ADDR'],
+        master_port=os.environ['MASTER_PORT'],
+    )
+
+
+def get_distributed_env(local_rank, rank, world_size):
+    env = os.environ.copy()
+    env["LOCAL_RANK"] = str(local_rank)
+    env["RANK"] = str(rank)
+    env["WORLD_SIZE"] = str(world_size)
+    return env
+
+
+def distributed_run(data_parallel, worker_fn, *args, **kwargs):
+    distributed_params = get_distributed_params()
+    local_rank = distributed_params['local_rank']
+    world_size = distributed_params['world_size']
+
+    if data_parallel or world_size <= 1:
+        worker_fn(*args, **kwargs)
+    elif local_rank is not None:
+        torch.cuda.set_device(int(local_rank))
+
+        torch.distributed.init_process_group(
+            backend='nccl', init_method="env://"
+        )
+        worker_fn(*args, **kwargs)
+    else:
+        workers = []
+        try:
+            for local_rank in range(torch.cuda.device_count()):
+                rank = distributed_params['start_rank'] + local_rank
+                env = get_distributed_env(local_rank, rank, world_size)
+                cmd = [sys.executable] + sys.argv.copy()
+                workers.append(subprocess.Popen(cmd, env=env))
+            for worker in workers:
+                worker.wait()
+        finally:
+            for worker in workers:
+                worker.kill()
+
+
+class DatasetFromSampler(Dataset):
+    def __init__(self, sampler: Sampler):
+        self.sampler = sampler
+        self.sampler_list = None
+
+    def __getitem__(self, index: int):
+        if self.sampler_list is None:
+            self.sampler_list = list(self.sampler)
+        return self.sampler_list[index]
+
+    def __len__(self) -> int:
+        return len(self.sampler)
+
+
+class DistributedSamplerOverSampler(DistributedSampler):
+    def __init__(self, sampler, num_replicas=None, rank=None, shuffle=True):
+        super(DistributedSamplerOverSampler, self).__init__(
+            DatasetFromSampler(sampler),
+            num_replicas=num_replicas,
+            rank=rank,
+            shuffle=shuffle
+        )
+        self.sampler = sampler
+
+    def __iter__(self):
+        self.dataset = DatasetFromSampler(self.sampler)
+        indexes_of_indexes = super().__iter__()
+        subsampler_indexes = self.dataset
+        return iter(itemgetter(*indexes_of_indexes)(subsampler_indexes))
+
+
+def process_components(
+    model: Model,
+    criterion: Criterion = None,
+    optimizer: Optimizer = None,
+    scheduler: Scheduler = None,
+    distributed_params: Dict = None,
+    device: Device = None,
+) -> Tuple[Model, Criterion, Optimizer, Scheduler, Device]:
+    """
+    Returns the processed model, criterion, optimizer, scheduler and device
+
+    Args:
+        model (Model): torch model
+        criterion (Criterion): criterion function
+        optimizer (Optimizer): optimizer
+        scheduler (Scheduler): scheduler
+        distributed_params (dict, optional): dict with the parameters
+            for distributed and FP16 methond
+        device (Device, optional): device
+    """
+    distributed_params = distributed_params or {}
+    distributed_params = copy.deepcopy(distributed_params)
+    distributed_params.update(get_distributed_params())
+    if device is None:
+        device = utils.get_device()
+
+    model: Model = utils.maybe_recursive_call(model, "to", device=device)
+
+    if utils.is_wrapped_with_ddp(model):
+        pass
+    elif get_rank() >= 0:
+        assert isinstance(model, nn.Module)
+        local_rank = distributed_params.pop('local_rank', 0)
+        device = f'cuda:{local_rank}'
+        model = utils.maybe_recursive_call(model, "to", device=device)
+
+        syncbn = distributed_params.pop("syncbn", False)
+        use_apex = distributed_params.pop("apex", True) and is_apex_available()
+
+        if use_apex:
+            import apex
+            amp_params = get_default_params(apex.amp.initialize, ["models", "optimizers"])
+            amp_params['opt_level'] = 'O0'
+            for dp in distributed_params:
+                if dp in amp_params:
+                    amp_params[dp] = distributed_params[dp]
+
+            amp_result = apex.amp.initialize(
+                model,
+                optimizer,
+                **amp_params
+            )
+            if optimizer is not None:
+                model, optimizer = amp_result
+            else:
+                model = amp_result
+
+            model = apex.parallel.DistributedDataParallel(model)
+
+            if syncbn:
+                model = apex.parallel.convert_syncbn_model(model)
+        else:
+            model = torch.nn.parallel.DistributedDataParallel(model,
+                                                              device_ids=[local_rank],
+                                                              output_device=local_rank)
+    elif torch.cuda.device_count() > 1:
+        if isinstance(model, nn.Module):
+            model = torch.nn.DataParallel(model)
+        elif isinstance(model, dict):
+            model = {k: torch.nn.DataParallel(v) for k, v in model.items()}
+
+    model: Model = utils.maybe_recursive_call(model, "to", device=device)
+
+    return model, criterion, optimizer, scheduler, device
+
+
+
+__all__ = [
+    "DistributedSamplerOverSampler", "get_rank", "process_components",
+    "is_apex_available", "assert_fp16_available", "distributed_run"
+]
+

--- a/catalyst/utils/distributed.py
+++ b/catalyst/utils/distributed.py
@@ -106,11 +106,20 @@ def get_distributed_params():
     )
 
 
-def get_distributed_env(local_rank, rank, world_size):
+def get_distributed_env(
+        local_rank,
+        rank,
+        world_size,
+        use_cuda_visible_devices=True
+):
     env = os.environ.copy()
-    env["LOCAL_RANK"] = str(local_rank)
     env["RANK"] = str(rank)
     env["WORLD_SIZE"] = str(world_size)
+    env["LOCAL_RANK"] = str(local_rank)
+    available_gpus = utils.get_available_gpus()
+    if use_cuda_visible_devices:
+        env["LOCAL_RANK"] = "0"
+        env["CUDA_VISIBLE_DEVICES"] = str(available_gpus[local_rank])
     return env
 
 

--- a/catalyst/utils/distributed.py
+++ b/catalyst/utils/distributed.py
@@ -19,8 +19,11 @@ from catalyst.utils.tools.typing import (
 
 def get_rank() -> int:
     """
-    If torch.distributed is initialized returns ``rank``, otherwise ``-1``
-    :return:
+    Returns the rank of the current worker.
+
+    Returns:
+         int: ``rank`` if torch.distributed is initialized,
+              otherwise ``-1``
     """
     if torch.distributed.is_initialized():
         return torch.distributed.get_rank()

--- a/catalyst/utils/misc.py
+++ b/catalyst/utils/misc.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, Optional  # isort:skip
+from typing import Any, Callable, Iterable, List, Optional  # isort:skip
 from datetime import datetime
 import inspect
 from itertools import tee
@@ -155,12 +155,14 @@ def args_are_not_none(*args: Optional[Any]) -> bool:
     return True
 
 
-def get_default_params(fn, exclude=None):
+def get_default_params(fn: Callable[..., Any], exclude: List[str] = None):
     """
-
-    :param fn:
-    :param exclude:
-    :return:
+    Return default parameters of Callable.
+    Args:
+        fn (Callable[..., Any]): target Callable
+        exclude (List[str]): exclude list of parameters
+    Returns:
+        dict: contains default parameters of `fn`
     """
     argspec = inspect.getfullargspec(fn)
     default_params = zip(

--- a/catalyst/utils/misc.py
+++ b/catalyst/utils/misc.py
@@ -1,6 +1,6 @@
 from typing import Any, Iterable, Optional  # isort:skip
-
 from datetime import datetime
+import inspect
 from itertools import tee
 from pathlib import Path
 import shutil
@@ -153,3 +153,20 @@ def args_are_not_none(*args: Optional[Any]) -> bool:
             return False
 
     return True
+
+
+def get_default_params(fn, exclude=None):
+    """
+
+    :param fn:
+    :param exclude:
+    :return:
+    """
+    argspec = inspect.getfullargspec(fn)
+    default_params = zip(
+        argspec.args[-len(argspec.defaults):], argspec.defaults
+    )
+    if exclude is not None:
+        default_params = filter(lambda x: x[0] not in exclude, default_params)
+    default_params = dict(default_params)
+    return default_params

--- a/catalyst/utils/tools/metric_manager.py
+++ b/catalyst/utils/tools/metric_manager.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from numbers import Number
 from time import time
 
+from catalyst.utils.distributed import distributed_mean
 from catalyst.utils.meters import AverageValueMeter
 
 
@@ -135,7 +136,9 @@ class MetricManager:
             metrics_dict[name] = value
 
         for name, value in metrics_dict.items():
-            self._batch_values[name] = self._to_single_value(value)
+            value = self._to_single_value(value)
+            value = distributed_mean(value)
+            self._batch_values[name] = value
 
 
 __all__ = ["TimerManager", "MetricManager"]

--- a/catalyst/utils/tools/metric_manager.py
+++ b/catalyst/utils/tools/metric_manager.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from numbers import Number
 from time import time
 
-from catalyst.utils.distributed import distributed_mean
+from catalyst.utils import distributed_mean
 from catalyst.utils.meters import AverageValueMeter
 
 

--- a/catalyst/utils/torch.py
+++ b/catalyst/utils/torch.py
@@ -1,7 +1,8 @@
+from typing import Dict, Iterable, List, Tuple, Union  # isort:skip
 import collections
+import copy
 import os
 import re
-from typing import Dict, Iterable, List, Union
 
 import numpy as np
 import safitty
@@ -11,7 +12,9 @@ from torch import nn
 import torch.backends.cudnn as cudnn
 
 from catalyst import utils
-from catalyst.utils.tools.typing import Device, Model, Optimizer
+from catalyst.utils.tools.typing import (
+    Criterion, Device, Model, Optimizer, Scheduler
+)
 
 
 def ce_with_logits(logits, target):

--- a/catalyst/utils/torch.py
+++ b/catalyst/utils/torch.py
@@ -5,14 +5,13 @@ from typing import Dict, Iterable, List, Union
 
 import numpy as np
 import safitty
+
 import torch
-import torch.backends.cudnn as cudnn
 from torch import nn
+import torch.backends.cudnn as cudnn
 
 from catalyst import utils
-from catalyst.utils.tools.typing import (
-    Device, Model, Optimizer
-)
+from catalyst.utils.tools.typing import Device, Model, Optimizer
 
 
 def ce_with_logits(logits, target):

--- a/catalyst/utils/torch.py
+++ b/catalyst/utils/torch.py
@@ -317,7 +317,7 @@ def detach(tensor: torch.Tensor) -> np.ndarray:
 __all__ = [
     "ce_with_logits", "log1p_exp", "normal_sample", "normal_logprob",
     "soft_update", "get_optimizable_params", "get_optimizer_momentum",
-    "set_optimizer_momentum", "get_device",
-    "get_available_gpus", "get_activation_fn", "any2device", "prepare_cudnn",
-    "process_model_params", "set_requires_grad", "get_network_output", "detach"
+    "set_optimizer_momentum", "get_device", "get_available_gpus",
+    "get_activation_fn", "any2device", "prepare_cudnn", "process_model_params",
+    "set_requires_grad", "get_network_output", "detach"
 ]

--- a/catalyst/utils/torch.py
+++ b/catalyst/utils/torch.py
@@ -1,19 +1,17 @@
-from typing import Dict, Iterable, List, Tuple, Union  # isort:skip
 import collections
-import copy
 import os
 import re
+from typing import Dict, Iterable, List, Union
 
 import numpy as np
 import safitty
-
 import torch
-from torch import nn
 import torch.backends.cudnn as cudnn
+from torch import nn
 
 from catalyst import utils
 from catalyst.utils.tools.typing import (
-    Criterion, Device, Model, Optimizer, Scheduler
+    Device, Model, Optimizer
 )
 
 
@@ -105,22 +103,6 @@ def set_optimizer_momentum(optimizer: Optimizer, value: float, index: int = 0):
         )
     elif momentum is not None:
         safitty.set(optimizer.param_groups, index, "momentum", value=value)
-
-
-def assert_fp16_available() -> None:
-    """
-    Asserts for installed and available Apex FP16
-    """
-    assert torch.backends.cudnn.enabled, \
-        "fp16 mode requires cudnn backend to be enabled."
-
-    try:
-        import apex  # noqa: F401
-        from apex import amp  # noqa: F401
-    except ImportError:
-        assert False, \
-            "NVidia Apex package must be installed. " \
-            "See https://github.com/NVIDIA/apex."
 
 
 def get_device() -> torch.device:
@@ -288,77 +270,6 @@ def process_model_params(
     return model_params
 
 
-def process_components(
-    model: Model,
-    criterion: Criterion = None,
-    optimizer: Optimizer = None,
-    scheduler: Scheduler = None,
-    distributed_params: Dict = None,
-    device: Device = None,
-) -> Tuple[Model, Criterion, Optimizer, Scheduler, Device]:
-    """
-    Returns the processed model, criterion, optimizer, scheduler and device
-
-    Args:
-        model (Model): torch model
-        criterion (Criterion): criterion function
-        optimizer (Optimizer): optimizer
-        scheduler (Scheduler): scheduler
-        distributed_params (dict, optional): dict with the parameters
-            for distributed and FP16 methond
-        device (Device, optional): device
-    """
-    distributed_params = distributed_params or {}
-    distributed_params = copy.deepcopy(distributed_params)
-    if device is None:
-        device = utils.get_device()
-
-    model: Model = utils.maybe_recursive_call(model, "to", device=device)
-
-    if utils.is_wrapped_with_ddp(model):
-        pass
-    elif len(distributed_params) > 0:
-        assert isinstance(model, nn.Module)
-        distributed_rank = distributed_params.pop("rank", -1)
-        syncbn = distributed_params.pop("syncbn", False)
-
-        if distributed_rank > -1:
-            torch.cuda.set_device(distributed_rank)
-            torch.distributed.init_process_group(
-                backend="nccl", init_method="env://"
-            )
-
-        if "opt_level" in distributed_params:
-            utils.assert_fp16_available()
-            from apex import amp
-
-            amp_result = amp.initialize(model, optimizer, **distributed_params)
-            if optimizer is not None:
-                model, optimizer = amp_result
-            else:
-                model = amp_result
-
-            if distributed_rank > -1:
-                from apex.parallel import DistributedDataParallel
-                model = DistributedDataParallel(model)
-
-                if syncbn:
-                    from apex.parallel import convert_syncbn_model
-                    model = convert_syncbn_model(model)
-
-        if distributed_rank <= -1 and torch.cuda.device_count() > 1:
-            model = torch.nn.DataParallel(model)
-    elif torch.cuda.device_count() > 1:
-        if isinstance(model, nn.Module):
-            model = torch.nn.DataParallel(model)
-        elif isinstance(model, dict):
-            model = {k: torch.nn.DataParallel(v) for k, v in model.items()}
-
-    model: Model = utils.maybe_recursive_call(model, "to", device=device)
-
-    return model, criterion, optimizer, scheduler, device
-
-
 def set_requires_grad(model: Model, requires_grad: bool):
     """
     Sets the ``requires_grad`` value for all model parameters.
@@ -407,7 +318,7 @@ def detach(tensor: torch.Tensor) -> np.ndarray:
 __all__ = [
     "ce_with_logits", "log1p_exp", "normal_sample", "normal_logprob",
     "soft_update", "get_optimizable_params", "get_optimizer_momentum",
-    "set_optimizer_momentum", "assert_fp16_available", "get_device",
+    "set_optimizer_momentum", "get_device",
     "get_available_gpus", "get_activation_fn", "any2device", "prepare_cudnn",
     "process_model_params", "set_requires_grad", "get_network_output", "detach"
 ]


### PR DESCRIPTION
## Description

Now `catalyst-dl run` automatically uses distributed data parallel mode. Using environment you can customize distributed data parallel mode. Also, `catalyst-dl run` has key `-dp`, which forces data parallel mode. It can be usefull for debugging. 

closes #625 
closes #626 
closes #627

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [x] I have read I need to click 'Login as guest' to see Teamcity build logs
- [x] I have checked the code-style using `make check-codestyle`.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.