### PR TITLE
improve wandb to log model grads and use custom time axis

### DIFF
--- a/catalyst/contrib/dl/runner/wandb.py
+++ b/catalyst/contrib/dl/runner/wandb.py
@@ -132,7 +132,7 @@ class WandbRunner(Runner):
         if self.log_on_epoch_end:
             for mode, metrics in \
                     self.state.metric_manager.epoch_values.items():
-                step = {'_epoch': self.state.epoch_log}
+                step = {"_epoch": self.state.epoch_log}
                 self._log_metrics(
                     metrics=metrics,
                     mode=mode,

--- a/catalyst/core/callbacks/optimizer.py
+++ b/catalyst/core/callbacks/optimizer.py
@@ -23,7 +23,6 @@ class OptimizerCallback(Callback):
         optimizer_key: str = None,
         loss_key: str = "loss",
         decouple_weight_decay: bool = True,
-        save_model_grads: bool = False
     ):
         """
         Args:
@@ -35,9 +34,6 @@ class OptimizerCallback(Callback):
             loss_key (str): key to get loss from ``state.loss``
             decouple_weight_decay (bool): If True - decouple weight decay
                 regularization.
-            save_model_grads (bool): If True - State.model_grads will
-                contain gradients calculated on backward propagation on current
-                batch
         """
         super().__init__(CallbackOrder.Optimizer)
         grad_clip_params: dict = grad_clip_params or {}
@@ -49,7 +45,6 @@ class OptimizerCallback(Callback):
         self.optimizer_key: str = optimizer_key
         self.loss_key: str = loss_key
         self.decouple_weight_decay = decouple_weight_decay
-        self.save_model_grads = save_model_grads
 
         self._optimizer_wd: List[float] = [0.0]
         self._accumulation_counter: int = 0
@@ -173,10 +168,18 @@ class OptimizerCallback(Callback):
                 grad_clip_fn=self.grad_clip_fn
             )
 
-            if self.save_model_grads:
-                for tag, value in model.named_parameters():
-                    tag = tag.replace(".", "/")
-                    state.model_grads[tag] = value.grad.cpu().numpy()
+            if hasattr(state, "model_grads"):
+                memo = set()
+                modules = model.named_modules()
+                for module_prefix, module in modules:
+                    module_name = module._get_name()
+                    members = module._parameters.items()
+                    for k, v in members:
+                        if v is None or v in memo:
+                            continue
+                        memo.add(v)
+                        tag = "{}/{}/{}".format(module_prefix.replace(".", "/"), module_name, k)
+                        state.model_grads[tag] = v.grad
 
             utils.maybe_recursive_call(model, "zero_grad")
 

--- a/catalyst/core/callbacks/optimizer.py
+++ b/catalyst/core/callbacks/optimizer.py
@@ -178,7 +178,8 @@ class OptimizerCallback(Callback):
                         if v is None or v in memo:
                             continue
                         memo.add(v)
-                        tag = "{}/{}/{}".format(module_prefix.replace(".", "/"), module_name, k)
+                        tag = "{}/{}/{}".format(
+                            module_prefix.replace(".", "/"), module_name, k)
                         state.model_grads[tag] = v.grad
 
             utils.maybe_recursive_call(model, "zero_grad")


### PR DESCRIPTION
## Description

I've added wandb.watch(model) to _pre_experiment_hook and extend _log_metric interface with
step

## Related Issue

#656 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [x] I have read I need to click 'Login as guest' to see Teamcity build logs
- [x] I have checked the code-style using `make check-codestyle`.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.