### PR TITLE
Fix bug in EarlyStoppingCallback with minimize=False

### DIFF
--- a/catalyst/dl/callbacks/misc.py
+++ b/catalyst/dl/callbacks/misc.py
@@ -25,7 +25,7 @@ class EarlyStoppingCallback(Callback):
         if minimize:
             self.is_better = lambda score, best: score <= (best - min_delta)
         else:
-            self.is_better = lambda score, best: score >= (best - min_delta)
+            self.is_better = lambda score, best: score >= (best + min_delta)
 
     def on_epoch_end(self, state: State) -> None:
         if state.stage.startswith("infer"):


### PR DESCRIPTION
## Description

This MR is fixing the bug in EarlyStoppingCallback described in #663 

## Related Issue

#663 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [ ] I have read I need to click 'Login as guest' to see Teamcity build logs
- [ ] I have checked the code-style using `make check-codestyle`.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.