### PR TITLE
Fix model tracing exception

### DIFF
--- a/catalyst/dl/utils/trace.py
+++ b/catalyst/dl/utils/trace.py
@@ -45,6 +45,7 @@ class _TracingModelWrapper(nn.Module):
         self.tracing_result = torch.jit.trace(
             method_model, *args, **kwargs
         )
+        return self.model.forward(*args, **kwargs)
 
 
 def trace_model(


### PR DESCRIPTION
## Description

`catalyst-dl trace` throw an exception when Runner has been configured to use output_keys

## Related Issue

none

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [x] I have checked the code-style using `make check-codestyle`.
- [ ] I have written tests for all new methods and classes that I created.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.
- [ ] I have read I need to click 'Login as guest' to see Teamcity build logs.
