### PR TITLE
improve wandb to log model grads and use custom time axis [REOPENED]

### DIFF
--- a/catalyst/contrib/runner/wandb.py
+++ b/catalyst/contrib/runner/wandb.py
@@ -16,7 +16,8 @@ class WandbRunner(Runner):
     Runner wrapper with wandb integration hooks.
     """
     @staticmethod
-    def _log_metrics(metrics: Dict, mode: str, suffix: str = ""):
+    def _log_metrics(metrics: Dict, mode: str,
+                     step: dict = {}, suffix: str = ""):
         def key_locate(key: str):
             """
             Wandb uses first symbol _ for it service purposes
@@ -35,6 +36,7 @@ class WandbRunner(Runner):
             f"{key_locate(key)}/{mode}{suffix}": value
             for key, value in metrics.items()
         }
+        metrics.update(step)
         wandb.log(metrics)
 
     def _init(
@@ -75,6 +77,9 @@ class WandbRunner(Runner):
             wandb.init(**monitoring_params, config=exp_config)
         else:
             wandb.init(**monitoring_params)
+
+        model = self.model
+        wandb.watch(model)
 
     def _post_experiment_hook(self, experiment: Experiment):
         logdir_src = Path(experiment.logdir)
@@ -125,10 +130,13 @@ class WandbRunner(Runner):
     def _run_epoch(self, loaders):
         super()._run_epoch(loaders=loaders)
         if self.log_on_epoch_end:
-            for mode, metrics in self.state.metrics.epoch_values.items():
+            for mode, metrics in \
+                    self.state.metric_manager.epoch_values.items():
+                step = {'_epoch': self.state.epoch_log}
                 self._log_metrics(
                     metrics=metrics,
                     mode=mode,
+                    step=step,
                     suffix=self.epoch_log_suffix
                 )
 


### PR DESCRIPTION
## Description
REOPENED
I've added wandb.watch(model) to _pre_experiment_hook and extend _log_metric interface with
step

## Related Issue

#656 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [x] I have read I need to click 'Login as guest' to see Teamcity build logs
- [x] I have checked the code-style using `make check-codestyle`.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.