### PR TITLE
Change docs to sphinx_rtd_theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ sys.path.insert(0, os.path.abspath(catalyst_root_path))
 # -- Project information -----------------------------------------------------
 
 project = "Catalyst"
-copyright = "{}, Scitator".format(datetime.datetime.now().year)
+copyright = "{}, Scitator".format(datetime.datetime.now().year)  # noqa: W0622
 author = "Sergey Kolesnikov"
 
 docs_repo = "catalyst"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,7 +126,7 @@ pygments_style = None
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "alabaster"
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ sys.path.insert(0, os.path.abspath(catalyst_root_path))
 # -- Project information -----------------------------------------------------
 
 project = "Catalyst"
-copyright = "{}, Scitator".format(datetime.datetime.now().year)  # noqa: W0622
+copyright = "{}, Scitator".format(datetime.datetime.now().year)
 author = "Sergey Kolesnikov"
 
 docs_repo = "catalyst"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,7 +83,6 @@ extensions = [
 ]
 
 autodoc_inherit_docstrings = False
-
 napoleon_google_docstring = True
 napoleon_include_init_with_doc = True
 napoleon_numpy_docstring = False

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 sphinx
+sphinx_rtd_theme


### PR DESCRIPTION
## Description

Change docs theme from "alabaster" to "sphinx_rtd_theme"

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [x] I have checked the code-style using `make check-codestyle`.
- [ ] I have written tests for all new methods and classes that I created.
- [x] I have written the docstring in Google format for all the methods and classes that I used.
- [x] I have checked the docs using `make check-docs`.
- [x] I have read I need to click 'Login as guest' to see Teamcity build logs.