### PR TITLE
Fix wandb wrong step problem (Fix #684)

### DIFF
--- a/catalyst/contrib/dl/runner/wandb.py
+++ b/catalyst/contrib/dl/runner/wandb.py
@@ -149,12 +149,18 @@ class WandbRunner(Runner):
             wandb.log(commit=True)
 
     def run_experiment(self, experiment: Experiment):
+        """Starts experiment
+        
+        Args:
+            experiment (Experiment): experiment class
+        """
         self._pre_experiment_hook(experiment=experiment)
         super().run_experiment(experiment=experiment)
         self._post_experiment_hook(experiment=experiment)
 
 
 class SupervisedWandbRunner(WandbRunner, SupervisedRunner):
+    """SupervisedRunner with WandB"""
     pass
 
 

--- a/catalyst/contrib/dl/runner/wandb.py
+++ b/catalyst/contrib/dl/runner/wandb.py
@@ -15,7 +15,9 @@ class WandbRunner(Runner):
     Runner wrapper with wandb integration hooks.
     """
     @staticmethod
-    def _log_metrics(metrics: Dict, mode: str, suffix: str = "", epoch: int = None):
+    def _log_metrics(
+        metrics: Dict, mode: str, suffix: str = "", epoch: int = None
+    ):
         def key_locate(key: str):
             """
             Wandb uses first symbol _ for it service purposes
@@ -136,7 +138,10 @@ class WandbRunner(Runner):
             )
             for mode, metrics in mode_metrics.items():
                 self._log_metrics(
-                    metrics=metrics, mode=mode, suffix=self.epoch_log_suffix, epoch=epoch
+                    metrics=metrics,
+                    mode=mode,
+                    suffix=self.epoch_log_suffix,
+                    epoch=epoch
                 )
             wandb.log(commit=True)
 

--- a/catalyst/contrib/dl/runner/wandb.py
+++ b/catalyst/contrib/dl/runner/wandb.py
@@ -16,7 +16,7 @@ class WandbRunner(Runner):
     """
     @staticmethod
     def _log_metrics(
-        metrics: Dict, mode: str, suffix: str = "", epoch: int = None
+        metrics: Dict, mode: str, suffix: str = "", commit: bool = True
     ):
         def key_locate(key: str):
             """
@@ -36,7 +36,7 @@ class WandbRunner(Runner):
             f"{key_locate(key)}/{mode}{suffix}": value
             for key, value in metrics.items()
         }
-        wandb.log(metrics, step=epoch)
+        wandb.log(metrics, commit=commit)
 
     def _init(
         self,
@@ -125,7 +125,10 @@ class WandbRunner(Runner):
             mode = self.state.loader_name
             metrics = self.state.batch_metrics
             self._log_metrics(
-                metrics=metrics, mode=mode, suffix=self.batch_log_suffix
+                metrics=metrics,
+                mode=mode,
+                suffix=self.batch_log_suffix,
+                commit=True
             )
 
     def _run_epoch(self, stage: str, epoch: int):
@@ -141,7 +144,7 @@ class WandbRunner(Runner):
                     metrics=metrics,
                     mode=mode,
                     suffix=self.epoch_log_suffix,
-                    epoch=epoch
+                    commit=False
                 )
             wandb.log(commit=True)
 

--- a/catalyst/contrib/dl/runner/wandb.py
+++ b/catalyst/contrib/dl/runner/wandb.py
@@ -161,7 +161,6 @@ class WandbRunner(Runner):
 
 class SupervisedWandbRunner(WandbRunner, SupervisedRunner):
     """SupervisedRunner with WandB"""
-    pass
 
 
 __all__ = ["WandbRunner", "SupervisedWandbRunner"]

--- a/catalyst/contrib/dl/runner/wandb.py
+++ b/catalyst/contrib/dl/runner/wandb.py
@@ -15,7 +15,7 @@ class WandbRunner(Runner):
     Runner wrapper with wandb integration hooks.
     """
     @staticmethod
-    def _log_metrics(metrics: Dict, mode: str, suffix: str = ""):
+    def _log_metrics(metrics: Dict, mode: str, suffix: str = "", epoch: int = None):
         def key_locate(key: str):
             """
             Wandb uses first symbol _ for it service purposes
@@ -34,7 +34,7 @@ class WandbRunner(Runner):
             f"{key_locate(key)}/{mode}{suffix}": value
             for key, value in metrics.items()
         }
-        wandb.log(metrics)
+        wandb.log(metrics, step=epoch)
 
     def _init(
         self,
@@ -136,8 +136,9 @@ class WandbRunner(Runner):
             )
             for mode, metrics in mode_metrics.items():
                 self._log_metrics(
-                    metrics=metrics, mode=mode, suffix=self.epoch_log_suffix
+                    metrics=metrics, mode=mode, suffix=self.epoch_log_suffix, epoch=epoch
                 )
+            wandb.log(commit=True)
 
     def run_experiment(self, experiment: Experiment):
         self._pre_experiment_hook(experiment=experiment)

--- a/catalyst/contrib/dl/runner/wandb.py
+++ b/catalyst/contrib/dl/runner/wandb.py
@@ -150,7 +150,7 @@ class WandbRunner(Runner):
 
     def run_experiment(self, experiment: Experiment):
         """Starts experiment
-        
+
         Args:
             experiment (Experiment): experiment class
         """


### PR DESCRIPTION
## Description

Exactly 10 steps from 0 to 9.
![image](https://user-images.githubusercontent.com/9883873/75763892-0c18b700-5d4e-11ea-8362-c21f71bf6921.png)


## Related Issue

https://github.com/catalyst-team/catalyst/issues/684

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [x] I have checked the code-style using `make check-codestyle`.
- [ ] I have written tests for all new methods and classes that I created.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [x] I have checked the docs using `make check-docs`.
- [x] I have read I need to click 'Login as guest' to see Teamcity build logs.
