### PR TITLE
fixed cutmix callback code

### DIFF
--- a/catalyst/contrib/dl/callbacks/cutmix_callback.py
+++ b/catalyst/contrib/dl/callbacks/cutmix_callback.py
@@ -58,7 +58,7 @@ class CutmixCallback(CriterionCallback):
         :return: loss value
         """
         if not self.is_needed:
-            return super()._compute_loss(state, criterion)
+            return super()._compute_loss_value(state, criterion)
 
         pred = state.output[self.output_key]
         y_a = state.input[self.input_key]


### PR DESCRIPTION
Cutmix callback does not work in the current version of the catalyst because of the `super()._compute_loss` call which had changed to `super()._compute_loss_value`.
