### PR TITLE
Fix batch_size and num_workers doubling

### DIFF
--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -407,8 +407,8 @@ class ConfigExperiment(Experiment):
         """Returns the loaders for a given stage"""
         data_params = dict(self.stages_config[stage]["data_params"])
 
-        batch_size = data_params.pop("batch_size", 1)
-        num_workers = data_params.pop("num_workers")
+        default_batch_size = data_params.pop("batch_size", 1)
+        default_num_workers = data_params.pop("num_workers")
         drop_last = data_params.pop("drop_last", False)
         per_gpu_scaling = data_params.pop("per_gpu_scaling", False)
         distributed_rank = utils.get_rank()
@@ -446,9 +446,10 @@ class ConfigExperiment(Experiment):
                 if isinstance(ds_, dict) and "sampler" in ds_:
                     ds_.pop("sampler", None)
 
-            batch_size = overridden_loader_params.pop("batch_size", batch_size)
+            batch_size = overridden_loader_params.\
+                pop("batch_size", default_batch_size)
             num_workers = overridden_loader_params.\
-                pop("num_workers", num_workers)
+                pop("num_workers", default_num_workers)
 
             if per_gpu_scaling and not distributed:
                 num_gpus = max(1, torch.cuda.device_count())


### PR DESCRIPTION
## Description

data_params: batch_size and num_workers grow twice for each other DataLoader since first

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

#397

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [ ] I have checked the code-style using `make check-codestyle`.
- [ ] I have written tests for all new methods and classes that I created.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.
- [x] I have read I need to click 'Login as guest' to see Teamcity build logs.
