### PR TITLE
Debug fix. A relative import changed to an absolute

### DIFF
--- a/catalyst/dl/__main__.py
+++ b/catalyst/dl/__main__.py
@@ -2,7 +2,7 @@ from argparse import ArgumentParser, RawTextHelpFormatter
 from collections import OrderedDict
 
 from catalyst.__version__ import __version__
-from .scripts import init, run, trace
+from catalyst.dl.scripts import init, run, trace
 
 COMMANDS = OrderedDict([
     ("init", init),

--- a/catalyst/rl/__main__.py
+++ b/catalyst/rl/__main__.py
@@ -2,7 +2,7 @@ from argparse import ArgumentParser, RawTextHelpFormatter
 from collections import OrderedDict
 
 from catalyst.__version__ import __version__
-from .scripts import dump_db, load_db, run_samplers, run_trainer
+from catalyst.rl.scripts import dump_db, load_db, run_samplers, run_trainer
 
 COMMANDS = OrderedDict(
     [


### PR DESCRIPTION
## Description

When we are debugging this module, we can not use relative imports.

Absolute imports are preferable all the time.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [ ] I have checked the code-style using `make check-codestyle`.
- [ ] I have written tests for all new methods and classes that I created.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.
- [ ] I have read I need to click 'Login as guest' to see Teamcity build logs.
