### PR TITLE
initialize port by random value or value, which depends of SLURM_JOB_ID

### DIFF
--- a/catalyst/utils/distributed.py
+++ b/catalyst/utils/distributed.py
@@ -125,7 +125,7 @@ def get_slurm_params():
     current_node = os.environ["SLURMD_NODENAME"]
     master_node = socket.gethostbyname(nodes[0])
     cur_node_idx = nodes.index(current_node)
-    job_id = os.getenv("SLURM_JOB_ID")
+    job_id = os.environ["SLURM_JOB_ID"]
     master_port = str(5*10**4 + int(job_id) % 10**4)
     return cur_node_idx, num_nodes, master_node, master_port
 

--- a/catalyst/utils/distributed.py
+++ b/catalyst/utils/distributed.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 import copy
 import os
+import random
 import socket
 import subprocess
 import sys
@@ -124,17 +125,20 @@ def get_slurm_params():
     current_node = os.environ["SLURMD_NODENAME"]
     master_node = socket.gethostbyname(nodes[0])
     cur_node_idx = nodes.index(current_node)
-    return cur_node_idx, num_nodes, master_node
+    job_id = os.getenv("SLURM_JOB_ID")
+    master_port = str(5*10**4 + int(job_id) % 10**4)
+    return cur_node_idx, num_nodes, master_node, master_port
 
 
 def get_distributed_params():
+    master_port = str(random.randint(5*10**4, 6*10**4))
     master_addr = "127.0.0.1"
     cur_node, num_nodes = 0, 1
     if is_slurm_available():
-        cur_node, num_nodes, master_addr = get_slurm_params()
+        cur_node, num_nodes, master_addr, master_port = get_slurm_params()
 
     os.environ["MASTER_ADDR"] = os.getenv("MASTER_ADDR", master_addr)
-    os.environ["MASTER_PORT"] = os.getenv("MASTER_PORT", "424242")
+    os.environ["MASTER_PORT"] = os.getenv("MASTER_PORT", master_port)
 
     workers_per_node = torch.cuda.device_count()
     start_rank = cur_node * workers_per_node


### PR DESCRIPTION
## Description

DDP couldn't start twice at the same time on the same machine, because the master port is hardcoded.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [ ] I have checked the code-style using `make check-codestyle`.
- [ ] I have written tests for all new methods and classes that I created.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.
- [ ] I have read I need to click 'Login as guest' to see Teamcity build logs.
