### PR TITLE
reduce confusion matrices to master

### DIFF
--- a/catalyst/dl/callbacks/confusion_matrix.py
+++ b/catalyst/dl/callbacks/confusion_matrix.py
@@ -97,13 +97,13 @@ class ConfusionMatrixCallback(Callback):
             [str(i) for i in range(self.num_classes)]
         confusion_matrix = self._compute_confusion_matrix()
 
-        if utils.get_rank() >= 0:
+        if state.distributed_rank >= 0:
             confusion_matrix = torch.from_numpy(confusion_matrix)
             confusion_matrix = confusion_matrix.to(utils.get_device())
             torch.distributed.reduce(confusion_matrix, 0)
             confusion_matrix = confusion_matrix.cpu().numpy()
 
-        if utils.get_rank() <= 0:
+        if state.distributed_rank <= 0:
             tb_callback = state.callbacks[self.tensorboard_callback_name]
             self._plot_confusion_matrix(
                 logger=tb_callback.loggers[state.loader_name],


### PR DESCRIPTION
## Description

Now confusion matrix calculates only by master node. But workers also have own confusion matrices. You can see NaN values in tensorboard confusion matrix without reducing confusion matrices over workers on small datasets. 

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [ ] I have checked the code-style using `make check-codestyle`.
- [ ] I have written tests for all new methods and classes that I created.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.
- [ ] I have read I need to click 'Login as guest' to see Teamcity build logs.
