### PR TITLE
Warn about missing packages only if environment variable is set

### DIFF
--- a/catalyst/contrib/dl/callbacks/__init__.py
+++ b/catalyst/contrib/dl/callbacks/__init__.py
@@ -17,7 +17,7 @@ except ImportError as ex:
     if os.environ.get("USE_ALCHEMY", "0") == "1":
         logger.warning(
             "alchemy not available, to install alchemy, "
-            "run `pip install alchemy-catalyst`."
+            "run `pip install alchemy`."
         )
         raise ex
 

--- a/catalyst/contrib/dl/callbacks/__init__.py
+++ b/catalyst/contrib/dl/callbacks/__init__.py
@@ -14,11 +14,11 @@ try:
     import alchemy
     from .alchemy import AlchemyLogger
 except ImportError as ex:
-    logger.warning(
-        "alchemy not available, to install alchemy, "
-        "run `pip install alchemy`."
-    )
     if os.environ.get("USE_ALCHEMY", "0") == "1":
+        logger.warning(
+            "alchemy not available, to install alchemy, "
+            "run `pip install alchemy-catalyst`."
+        )
         raise ex
 
 try:


### PR DESCRIPTION
## Description

Why should people get this warning if they don't use `alchemy`? I think it should be under the `if` statement just as `Neptune`.

Fast example screenshot:
![image](https://user-images.githubusercontent.com/9883873/77356815-167c0e80-6d58-11ea-8c30-b7fdea34c055.png)


## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [ ] I have checked the code-style using `make check-codestyle`.
- [ ] I have written tests for all new methods and classes that I created.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.
- [x] I have read I need to click 'Login as guest' to see Teamcity build logs.
