### PR TITLE
add `utils.get_network_output` as it used in catalyst.classification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,16 +29,17 @@ If you are not familiar with creating a Pull Request, here are some guides:
 
 ##### Contribution best practices
 
-1. Install `catalyst-codestyle`
+1. Install requirements
     ```
-    pip install -U catalyst-codestyle
+    pip install -r requirements/requirements-dev.txt
     ```
-1. Break your work into small, single-purpose updates if possible.
+2. Break your work into small, single-purpose updates if possible.
 It's much harder to merge in a large change with a lot of disjoint features.
-2. Submit the update as a GitHub pull request against the `master` branch.
-3. Make sure that you provide docstrings for all your new methods and classes
-4. Make sure that your code passes the unit tests.
+3. Submit the update as a GitHub pull request against the `master` branch.
+4. Make sure that you provide docstrings for all your new methods and classes.
 5. Add new unit tests for your code.
+6. Check the [codestyle](#codestyle)
+7. Make sure that your code [passes the unit tests](#unit-tests)
 
 #### Codestyle
 
@@ -49,6 +50,14 @@ catalyst-make-codestyle && catalyst-check-codestyle
 ```
 
 Make sure to have your python packages complied with `requirements/requirements.txt` and `requirements/requirements-dev.txt` to get codestyle run clean.
+
+#### Unit tests
+
+Do not forget to check that your code passes the unit tests
+
+```bash
+pytest .
+```
 
 ## Documentation
 

--- a/catalyst/utils/__init__.py
+++ b/catalyst/utils/__init__.py
@@ -53,6 +53,7 @@ from .torch import (
     process_model_params,
     set_optimizer_momentum,
     set_requires_grad,
+    get_network_output,
 )
 from .distributed import (
     get_nn_from_ddp_module,

--- a/catalyst/utils/tests/test_torch.py
+++ b/catalyst/utils/tests/test_torch.py
@@ -1,0 +1,45 @@
+import torch
+from torch import nn
+
+from .. import torch as utils  # import
+
+
+def test_network_output():
+    """
+    Test for ``catalyst.utils.torch.get_network_output``
+    """
+    # case #0
+    net = nn.Identity()
+    assert utils.get_network_output(net, (1, 20)).shape == (1, 1, 20)
+
+    # case #1
+    net = nn.Linear(20, 10)
+    assert utils.get_network_output(net, (1, 20)).shape == (1, 1, 10)
+
+    # case #2
+    class Net(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.net1 = nn.Linear(20, 10)
+            self.net2 = nn.Linear(10, 5)
+
+        def forward(self, x, y):
+            z = torch.cat((self.net1(x), self.net2(y)), dim=-1)
+            return z
+
+    net = Net()
+    assert utils.get_network_output(net, (1, 20), (1, 10)).shape == (1, 1, 15)
+
+    # case #3
+    class Net(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.net = nn.Linear(20, 10)
+
+        def forward(self, input):
+            z = self.net(input["x"])
+            return z
+
+    net = Net()
+    input_shapes = {"x": (1, 20)}
+    assert utils.get_network_output(net, input_shapes).shape == (1, 1, 10)

--- a/catalyst/utils/tests/test_torch.py
+++ b/catalyst/utils/tests/test_torch.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import torch
 from torch import nn
 
@@ -5,41 +7,52 @@ from .. import torch as torch_utils
 
 
 def test_network_output():
-    """
-    Test for ``catalyst.utils.torch.get_network_output``
-    """
-    # case #0
+    """Test for ``catalyst.utils.torch.get_network_output``."""
+    # case #1 - test net with one input variable
     net = nn.Identity()
     assert torch_utils.get_network_output(net, (1, 20)).shape == (1, 1, 20)
 
-    # case #1
     net = nn.Linear(20, 10)
     assert torch_utils.get_network_output(net, (1, 20)).shape == (1, 1, 10)
 
-    # case #2
+    # case #2 - test net with several input variables
     class Net(nn.Module):
         def __init__(self):
             super().__init__()
             self.net1 = nn.Linear(20, 10)
             self.net2 = nn.Linear(10, 5)
 
-        def forward(self, x, y):
+        def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
             z = torch.cat((self.net1(x), self.net2(y)), dim=-1)
             return z
 
     net = Net()
     assert torch_utils.get_network_output(net, (20,), (10,)).shape == (1, 15)
 
-    # case #3
+    # case #3 - test net with key-value input
     class Net(nn.Module):
         def __init__(self):
             super().__init__()
             self.net = nn.Linear(20, 10)
 
-        def forward(self, input):
-            z = self.net(input["x"])
-            return z
+        def forward(self, *, x: torch.Tensor = None) -> torch.Tensor:
+            y = self.net(x)
+            return y
 
     net = Net()
-    input_shapes = {"x": (1, 20)}
-    assert torch_utils.get_network_output(net, input_shapes).shape == (1, 1, 10)
+    input_shapes = {"x": (20,)}
+    assert torch_utils.get_network_output(net, **input_shapes).shape == (1, 10)
+
+    # case #4 - test net with dict of variables input
+    class Net(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.net = nn.Linear(20, 10)
+
+        def forward(self, x: Dict[str, torch.Tensor]) -> torch.Tensor:
+            y = self.net(x["x"])
+            return y
+
+    net = Net()
+    input_shapes = {"x": (20,)}
+    assert torch_utils.get_network_output(net, input_shapes).shape == (1, 10)

--- a/catalyst/utils/tests/test_torch.py
+++ b/catalyst/utils/tests/test_torch.py
@@ -1,7 +1,7 @@
 import torch
 from torch import nn
 
-from .. import torch as utils  # import
+from .. import torch as torch_utils
 
 
 def test_network_output():
@@ -10,11 +10,11 @@ def test_network_output():
     """
     # case #0
     net = nn.Identity()
-    assert utils.get_network_output(net, (1, 20)).shape == (1, 1, 20)
+    assert torch_utils.get_network_output(net, (1, 20)).shape == (1, 1, 20)
 
     # case #1
     net = nn.Linear(20, 10)
-    assert utils.get_network_output(net, (1, 20)).shape == (1, 1, 10)
+    assert torch_utils.get_network_output(net, (1, 20)).shape == (1, 1, 10)
 
     # case #2
     class Net(nn.Module):
@@ -28,7 +28,7 @@ def test_network_output():
             return z
 
     net = Net()
-    assert utils.get_network_output(net, (1, 20), (1, 10)).shape == (1, 1, 15)
+    assert torch_utils.get_network_output(net, (20,), (10,)).shape == (1, 15)
 
     # case #3
     class Net(nn.Module):
@@ -42,4 +42,4 @@ def test_network_output():
 
     net = Net()
     input_shapes = {"x": (1, 20)}
-    assert utils.get_network_output(net, input_shapes).shape == (1, 1, 10)
+    assert torch_utils.get_network_output(net, input_shapes).shape == (1, 1, 10)

--- a/catalyst/utils/torch.py
+++ b/catalyst/utils/torch.py
@@ -251,6 +251,11 @@ def get_network_output(net: Model, *input_shapes):
     Args:
         net (Model): the model
         *args: variable length argument list of shapes
+
+    Examples:
+        >>> net = nn.Linear(10, 5)
+        >>> utils.get_network_output(net, (1, 10))
+        tensor([[[-0.2665,  0.5792,  0.9757, -0.5782,  0.1530]]])
     """
     inputs = []
     for input_shape in input_shapes:

--- a/catalyst/utils/torch.py
+++ b/catalyst/utils/torch.py
@@ -244,6 +244,27 @@ def set_requires_grad(model: Model, requires_grad: bool):
         param.requires_grad = requires_grad
 
 
+def get_network_output(net: Model, *input_shapes):
+    """
+    For each input shape returns an output tensor
+
+    Args:
+        net (Model): the model
+        *args: variable length argument list of shapes
+    """
+    inputs = []
+    for input_shape in input_shapes:
+        if isinstance(input_shape, dict):
+            input_t = {}
+            for key, input_shape_ in input_shape.items():
+                input_t[key] = torch.Tensor(torch.randn((1,) + input_shape_))
+        else:
+            input_t = torch.Tensor(torch.randn((1,) + input_shape))
+        inputs.append(input_t)
+    output_t = net(*inputs)
+    return output_t
+
+
 __all__ = [
     "get_optimizable_params",
     "get_optimizer_momentum",
@@ -255,4 +276,5 @@ __all__ = [
     "prepare_cudnn",
     "process_model_params",
     "set_requires_grad",
+    "get_network_output",
 ]

--- a/catalyst/utils/torch.py
+++ b/catalyst/utils/torch.py
@@ -244,29 +244,42 @@ def set_requires_grad(model: Model, requires_grad: bool):
         param.requires_grad = requires_grad
 
 
-def get_network_output(net: Model, *input_shapes):
+def get_network_output(net: Model, *input_shapes_args, **input_shapes_kwargs):
     """
     For each input shape returns an output tensor
 
     Args:
         net (Model): the model
-        *args: variable length argument list of shapes
+        *input_shapes_args: variable length argument list of shapes
+        **input_shapes_kwargs:
 
     Examples:
         >>> net = nn.Linear(10, 5)
         >>> utils.get_network_output(net, (1, 10))
         tensor([[[-0.2665,  0.5792,  0.9757, -0.5782,  0.1530]]])
     """
-    inputs = []
-    for input_shape in input_shapes:
+
+    def _rand_sample(
+        input_shape,
+    ) -> Union[torch.Tensor, Dict[str, torch.Tensor]]:
         if isinstance(input_shape, dict):
-            input_t = {}
-            for key, input_shape_ in input_shape.items():
-                input_t[key] = torch.Tensor(torch.randn((1,) + input_shape_))
+            input_t = {
+                key: torch.Tensor(torch.randn((1,) + input_shape_))
+                for key, input_shape_ in input_shape.items()
+            }
         else:
             input_t = torch.Tensor(torch.randn((1,) + input_shape))
-        inputs.append(input_t)
-    output_t = net(*inputs)
+        return input_t
+
+    input_args = [
+        _rand_sample(input_shape) for input_shape in input_shapes_args
+    ]
+    input_kwargs = {
+        key: _rand_sample(input_shape)
+        for key, input_shape in input_shapes_kwargs.items()
+    }
+
+    output_t = net(*input_args, **input_kwargs)
     return output_t
 
 

--- a/teamcity/py_codestyle.sh
+++ b/teamcity/py_codestyle.sh
@@ -10,4 +10,5 @@ pip install -r requirements/requirements-dev.txt
 pip install -r docs/requirements.txt
 
 catalyst-check-codestyle
+pytest .
 make check-docs


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
[link](http://66.248.205.49:8111/viewLog.html?buildTypeId=Classification_Tests&buildId=24228&tab=buildLog&logTab=tree&filter=debug&expand=all&_focus=1800)

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [x] I have checked the code style using `catalyst-check-codestyle` (`pip install -U catalyst-codestyle`).
- [x] I have written tests for all new methods and classes that I created.
- [x] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.
- [x] I have read I need to click 'Login as guest' to see Teamcity build logs.
