### PR TITLE
Fix division by zero

### DIFF
--- a/catalyst/core/callbacks/timer.py
+++ b/catalyst/core/callbacks/timer.py
@@ -2,6 +2,9 @@ from catalyst.core import Callback, CallbackNode, CallbackOrder, State
 from catalyst.utils.tools.time_manager import TimeManager
 
 
+EPS = 1e-8
+
+
 class TimerCallback(Callback):
     """Logs pipeline execution time."""
 
@@ -48,7 +51,7 @@ class TimerCallback(Callback):
 
         # @TODO: just a trick
         self.timer.elapsed["_timer/_fps"] = (
-            state.batch_size / (self.timer.elapsed["_timer/batch_time"] + 1e-8)
+            state.batch_size / (self.timer.elapsed["_timer/batch_time"] + EPS)
         )
         for key, value in self.timer.elapsed.items():
             state.batch_metrics[key] = value

--- a/catalyst/core/callbacks/timer.py
+++ b/catalyst/core/callbacks/timer.py
@@ -1,7 +1,6 @@
 from catalyst.core import Callback, CallbackNode, CallbackOrder, State
 from catalyst.utils.tools.time_manager import TimeManager
 
-
 EPS = 1e-8
 
 

--- a/catalyst/core/callbacks/timer.py
+++ b/catalyst/core/callbacks/timer.py
@@ -49,8 +49,8 @@ class TimerCallback(Callback):
         self.timer.stop("_timer/batch_time")
 
         # @TODO: just a trick
-        self.timer.elapsed["_timer/_fps"] = (
-            state.batch_size / (self.timer.elapsed["_timer/batch_time"] + EPS)
+        self.timer.elapsed["_timer/_fps"] = state.batch_size / (
+            self.timer.elapsed["_timer/batch_time"] + EPS
         )
         for key, value in self.timer.elapsed.items():
             state.batch_metrics[key] = value

--- a/catalyst/core/callbacks/timer.py
+++ b/catalyst/core/callbacks/timer.py
@@ -48,7 +48,7 @@ class TimerCallback(Callback):
 
         # @TODO: just a trick
         self.timer.elapsed["_timer/_fps"] = (
-            state.batch_size / self.timer.elapsed["_timer/batch_time"]
+            state.batch_size / (self.timer.elapsed["_timer/batch_time"] + 1e-8)
         )
         for key, value in self.timer.elapsed.items():
             state.batch_metrics[key] = value


### PR DESCRIPTION
In rare cases, when processing last batch in validation dataset (with batch size = 1) batch_time can become zero (maybe due to windows timer precision) and cause run-time error.
Adding small epsilon seems to do the job :)

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [x] I have checked the code style using `catalyst-check-codestyle` (`pip install -U catalyst-codestyle`).
- [ ] I have written tests for all new methods and classes that I created.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.
- [ ] I have read I need to click 'Login as guest' to see Teamcity build logs.
