### PR TITLE
Set num_epochs = 1 as default in State

### DIFF
--- a/catalyst/core/state.py
+++ b/catalyst/core/state.py
@@ -3,8 +3,6 @@ from collections import defaultdict, OrderedDict
 from pathlib import Path
 import warnings
 
-import numpy as np
-
 from torch.utils.data import DataLoader
 
 from catalyst.core import utils

--- a/catalyst/core/state.py
+++ b/catalyst/core/state.py
@@ -286,7 +286,7 @@ class State(FrozenClass):
         callbacks: Dict[str, "Callback"] = None,
         logdir: str = None,
         stage: str = STAGE_INFER_PREFIX,
-        num_epochs: int = None,
+        num_epochs: int = 1,
         main_metric: str = STATE_MAIN_METRIC,
         minimize_metric: bool = True,
         valid_loader: str = LOADER_VALID_PREFIX,
@@ -341,7 +341,7 @@ class State(FrozenClass):
 
         self.stage_name: str = stage
         self.epoch: int = 1
-        self.num_epochs: int = num_epochs or np.iinfo(np.int32).max
+        self.num_epochs: int = num_epochs
 
         self.loader_name: str = None
         self.loader_step: int = 0


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
Default num_epochs values in State class was equal to maximal integer value, so it leads to behaviour when inference stage has no provided num_epochs value in config, and we've got infinitely long repeated cycle. Now it defaults to 1 to avoid these cases.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [x] I have checked the code style using `catalyst-check-codestyle` (`pip install -U catalyst-codestyle`).
- [x] I have written tests for all new methods and classes that I created.
- [x] I have written the docstring in Google format for all the methods and classes that I used.
- [x] I have checked the docs using `make check-docs`.
- [x] I have read I need to click 'Login as guest' to see Teamcity build logs.
