### PR TITLE
Minor issue in segmentation tutorial

### DIFF
--- a/examples/notebooks/segmentation-tutorial.ipynb
+++ b/examples/notebooks/segmentation-tutorial.ipynb
@@ -1242,7 +1242,7 @@
     "%matplotlib inline \n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "heatmap = utils.detach(runner.callbacks[\"infer\"].heatmap[0])\n",
+    "heatmap = utils.detach(runner.state.callbacks[\"infer\"].heatmap[0])\n",
     "plt.figure(figsize=(20, 9))\n",
     "plt.imshow(heatmap, cmap=\"hot\", interpolation=\"nearest\")\n",
     "plt.show()"


### PR DESCRIPTION
## Description

runner.callbacks["infer"] gives attribute error, should be runner.state.callbacks["infer"]

Might be because of a version change of catalyst

## Related Issue

None

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x ] I have read the [Code of Conduct](https://github.com/catalyst-team/catalyst/blob/master/CODE_OF_CONDUCT.md) document.
- [x ] I have read the [Contributing](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md) guide.
- [ ] I have checked the code style using `catalyst-check-codestyle` (`pip install -U catalyst-codestyle`).
- [ ] I have written tests for all new methods and classes that I created.
- [ ] I have written the docstring in Google format for all the methods and classes that I used.
- [ ] I have checked the docs using `make check-docs`.
- [ ] I have read I need to click 'Login as guest' to see Teamcity build logs.
