### PR TITLE
VerboseLogger: change _timers to _timer (#772)

### DIFF
--- a/catalyst/core/callbacks/logging.py
+++ b/catalyst/core/callbacks/logging.py
@@ -44,7 +44,7 @@ class VerboseLogger(Callback):
     def _need_show(self, key: str):
         not_is_never_shown: bool = key not in self.never_show
         is_always_shown: bool = key in self.always_show
-        not_basic = not (key.startswith("_base") or key.startswith("_timers"))
+        not_basic = not (key.startswith("_base") or key.startswith("_timer"))
 
         result = not_is_never_shown and (is_always_shown or not_basic)
 


### PR DESCRIPTION
## Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contribution guide](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md), Pull Request section?
- [ ] Did you check the code style? `catalyst-make-codestyle && catalyst-check-codestyle` (`pip install -U catalyst-codestyle`).
- [ ] Did you make sure to update the docs? We use Google format for all the methods and classes.
- [ ] Did you check the docs with `make check-docs`?
- [ ] Did you write any new necessary tests?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/catalyst-team/catalyst/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->


## Description
The default timer metrics are called `_timer/...` not `_timers/...` which means this check wasn't working as intended.
<!-- Add a more detailed description of the changes if needed. -->


## Related Issue
https://github.com/catalyst-team/catalyst/issues/772
<!-- If your PR refers to a related issue, link it here. -->


## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

**You can use 'Login as guest' to see Teamcity build logs.**


<!-- Thank you for your contribution! -->