### PR TITLE
fixed #854 EarlyStoppingCallback considers first epoch as bad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - `.dependabot/config.yml` contained invalid details ([#781](https://github.com/catalyst-team/catalyst/issues/781))
 - `LanguageModelingDataset` ([#841](https://github.com/catalyst-team/catalyst/pull/841))
+- EarlyStoppingCallback considers first epoch as bad
+ ([#854](https://github.com/catalyst-team/catalyst/issues/854))
+
 
 ## [20.06] - 2020-06-04
 

--- a/catalyst/core/callbacks/early_stop.py
+++ b/catalyst/core/callbacks/early_stop.py
@@ -51,9 +51,7 @@ class EarlyStoppingCallback(Callback):
             return
 
         score = runner.valid_metrics[self.metric]
-        if self.best_score is None:
-            self.best_score = score
-        if self.is_better(score, self.best_score):
+        if self.best_score is None or self.is_better(score, self.best_score):
             self.num_bad_epochs = 0
             self.best_score = score
         else:

--- a/catalyst/core/callbacks/tests/test_early_stop.py
+++ b/catalyst/core/callbacks/tests/test_early_stop.py
@@ -1,0 +1,17 @@
+from unittest.mock import MagicMock, PropertyMock
+
+from catalyst.core import EarlyStoppingCallback
+
+
+def test_patience1():
+    """@TODO: Docs. Contribution is welcome."""
+    early_stop = EarlyStoppingCallback(1)
+    runner = MagicMock()
+    type(runner).stage_name = PropertyMock(return_value="training")
+    type(runner).valid_metrics = PropertyMock(return_value={"loss": 0.001})
+    stop_mock = PropertyMock(return_value=False)
+    type(runner).need_early_stop = stop_mock
+
+    early_stop.on_epoch_end(runner)
+
+    assert stop_mock.mock_calls == []


### PR DESCRIPTION
## Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contribution guide](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md)?
- [x] Did you check the code style? `catalyst-make-codestyle && catalyst-check-codestyle` (`pip install -U catalyst-codestyle`).
- [x] Did you make sure to update the docs? We use Google format for all the methods and classes.
- [x] Did you check the docs with `make check-docs`?
- [x] Did you write any new necessary tests?
- [x] Did you add your new functionality to the docs?
- [x] Did you update the [CHANGELOG](https://github.com/catalyst-team/catalyst/CHANGELOG.md)?
- [x] **You can use 'Login as guest' to see Teamcity build logs.**



## Description
Fixed [EarlyStoppingCallback considers first epoch as bad #854](https://github.com/catalyst-team/catalyst/issues/854)


## Related Issue
[EarlyStoppingCallback considers first epoch as bad #854](https://github.com/catalyst-team/catalyst/issues/854)


## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

<!-- Thank you for your contribution! -->