### PR TITLE
Fix runtime warning on pytorch 1.6

### DIFF
--- a/catalyst/core/runner.py
+++ b/catalyst/core/runner.py
@@ -819,7 +819,7 @@ class IRunner(ABC, IRunnerLegacy, FrozenClass):
                 from DataLoader.
         """
         if isinstance(batch, dict):
-            self.batch_size = next(iter(batch.values())).shape[0]
+            self.batch_size = len(next(iter(batch.values())))
         else:
             self.batch_size = len(batch[0])
         self.global_sample_step += self.batch_size

--- a/catalyst/utils/components.py
+++ b/catalyst/utils/components.py
@@ -94,13 +94,14 @@ def process_components(
         if is_apex_available:
             import apex
 
+            if syncbn:
+                model = apex.parallel.convert_syncbn_model(model)
+
             model, optimizer = initialize_apex(
                 model, optimizer, **distributed_params
             )
             model = apex.parallel.DistributedDataParallel(model)
 
-            if syncbn:
-                model = apex.parallel.convert_syncbn_model(model)
         else:
             model = nn.parallel.DistributedDataParallel(
                 model, device_ids=[local_rank], output_device=local_rank

--- a/catalyst/utils/distributed.py
+++ b/catalyst/utils/distributed.py
@@ -126,10 +126,14 @@ def get_distributed_mean(value: Union[float, torch.Tensor]):
     """Computes distributed mean among all nodes."""
     if check_torch_distributed_initialized():
         # Fix for runtime warning:
-        # To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or
-        # sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
+        # To copy construct from a tensor, it is recommended to use 
+        # sourceTensor.clone().detach() or 
+        # sourceTensor.clone().detach().requires_grad_(True), 
+        # rather than torch.tensor(sourceTensor).
         if torch.is_tensor(value):
-            value = value.clone().detach().to(device=f"cuda:{torch.cuda.current_device()}")
+            value = value.clone().detach().to(
+                device=f"cuda:{torch.cuda.current_device()}"
+            )
         else:
             value = torch.tensor(
                 value,

--- a/catalyst/utils/distributed.py
+++ b/catalyst/utils/distributed.py
@@ -125,12 +125,18 @@ def get_rank() -> int:
 def get_distributed_mean(value: Union[float, torch.Tensor]):
     """Computes distributed mean among all nodes."""
     if check_torch_distributed_initialized():
-        value = torch.tensor(
-            value,
-            dtype=torch.float,
-            device=f"cuda:{torch.cuda.current_device()}",
-            requires_grad=False,
-        )
+        # Fix for runtime warning:
+        # To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or
+        # sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
+        if torch.is_tensor(value):
+            value = value.clone().detach().to(device=f"cuda:{torch.cuda.current_device()}")
+        else:
+            value = torch.tensor(
+                value,
+                dtype=torch.float,
+                device=f"cuda:{torch.cuda.current_device()}",
+                requires_grad=False,
+            )
         torch.distributed.all_reduce(value)
         value = float(value.item() / torch.distributed.get_world_size())
     return value

--- a/catalyst/utils/distributed.py
+++ b/catalyst/utils/distributed.py
@@ -126,13 +126,15 @@ def get_distributed_mean(value: Union[float, torch.Tensor]):
     """Computes distributed mean among all nodes."""
     if check_torch_distributed_initialized():
         # Fix for runtime warning:
-        # To copy construct from a tensor, it is recommended to use 
-        # sourceTensor.clone().detach() or 
-        # sourceTensor.clone().detach().requires_grad_(True), 
+        # To copy construct from a tensor, it is recommended to use
+        # sourceTensor.clone().detach() or
+        # sourceTensor.clone().detach().requires_grad_(True),
         # rather than torch.tensor(sourceTensor).
         if torch.is_tensor(value):
-            value = value.clone().detach().to(
-                device=f"cuda:{torch.cuda.current_device()}"
+            value = (
+                value.clone()
+                .detach()
+                .to(device=f"cuda:{torch.cuda.current_device()}")
             )
         else:
             value = torch.tensor(


### PR DESCRIPTION
## Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contribution guide](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md)?
- [x] Did you check the code style? `catalyst-make-codestyle && catalyst-check-codestyle` (`pip install -U catalyst-codestyle`).
- [x] Did you make sure to update the docs? We use Google format for all the methods and classes.
- [x] Did you check the docs with `make check-docs`?
- [x] Did you write any new necessary tests?
- [x] Did you add your new functionality to the docs?
- [x] Did you update the [CHANGELOG](https://github.com/catalyst-team/catalyst/CHANGELOG.md)?
- [x] **You can use 'Login as guest' to see Teamcity build logs.**

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->


## Description

Fixes runtime warning in PyTorch 1.6 in distributed training mode caused by creation of tensor copy from another tensor.
```
# To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or
# sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
```

## Related Issue

None

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

<!-- Thank you for your contribution! -->