### PR TITLE
Fix deprecated call

### DIFF
--- a/catalyst/core/callbacks/optimizer.py
+++ b/catalyst/core/callbacks/optimizer.py
@@ -92,7 +92,7 @@ class OptimizerCallback(Callback):
         for group, wd in zip(optimizer.param_groups, optimizer_wds):
             if wd > 0:
                 for param in group["params"]:
-                    param.data = param.data.add(-wd * group["lr"], param.data)
+                    param.data = param.data.add(param.data, -wd * group["lr"])
             if grad_clip_fn is not None:
                 grad_clip_fn(group["params"])
         # optimize parameters


### PR DESCRIPTION
## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ x ] Did you read the [contribution guide](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md)?
- [ ] Did you check the code style? `catalyst-make-codestyle && catalyst-check-codestyle` (`pip install -U catalyst-codestyle`).
- [ ] Did you make sure to update the docs? We use Google format for all the methods and classes.
- [ ] Did you check the docs with `make check-docs`?
- [ ] Did you write any new necessary tests?
- [ ] Did you add your new functionality to the docs?
- [ ] Did you update the [CHANGELOG](https://github.com/catalyst-team/catalyst/CHANGELOG.md)?
- [x] **You can use 'Login as guest' to see Teamcity build logs.**

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->


## Description

Since pytorch==1.6.0 this call is deprecated. Pytorch shows a lot of warnings, it seems to be best avoided.
```
This overload of add is deprecated:
	add(Number alpha, Tensor other)
Consider using one of the following signatures instead:
	add(Tensor other, *, Number alpha) (Triggered internally at  /pytorch/torch/csrc/utils/python_arg_parser.cpp:766.)
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->


## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

<!-- Thank you for your contribution! -->