### PR TITLE
Native automatic mixed precision training support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - `force` and `bert-level` keywords to `catalyst-data text2embedding` ([#917](https://github.com/catalyst-team/catalyst/pull/917))
-
 - `OptunaCallback` to `catalyst.contrib` ([#915](https://github.com/catalyst-team/catalyst/pull/915))
 - Multi-scheduler support for multi-optimizer case ([#923](https://github.com/catalyst-team/catalyst/pull/923))
+- Native mixed-precision training support ([#740](https://github.com/catalyst-team/catalyst/issues/740))
 
 ### Changed
 

--- a/catalyst/core/callbacks/__init__.py
+++ b/catalyst/core/callbacks/__init__.py
@@ -29,7 +29,10 @@ from catalyst.core.callbacks.metrics import (
     MetricAggregationCallback,
     MetricManagerCallback,
 )
-from catalyst.core.callbacks.optimizer import OptimizerCallback, AMPOptimizerCallback
+from catalyst.core.callbacks.optimizer import (
+    OptimizerCallback,
+    AMPOptimizerCallback,
+)
 from catalyst.core.callbacks.periodic_loader import PeriodicLoaderCallback
 from catalyst.core.callbacks.scheduler import LRUpdater, SchedulerCallback
 from catalyst.core.callbacks.timer import TimerCallback

--- a/catalyst/core/callbacks/__init__.py
+++ b/catalyst/core/callbacks/__init__.py
@@ -29,7 +29,7 @@ from catalyst.core.callbacks.metrics import (
     MetricAggregationCallback,
     MetricManagerCallback,
 )
-from catalyst.core.callbacks.optimizer import OptimizerCallback
+from catalyst.core.callbacks.optimizer import OptimizerCallback, AMPOptimizerCallback
 from catalyst.core.callbacks.periodic_loader import PeriodicLoaderCallback
 from catalyst.core.callbacks.scheduler import LRUpdater, SchedulerCallback
 from catalyst.core.callbacks.timer import TimerCallback

--- a/catalyst/core/callbacks/optimizer.py
+++ b/catalyst/core/callbacks/optimizer.py
@@ -270,7 +270,6 @@ class AMPOptimizerCallback(Callback):
         # Initialized at on_state_start()
         self.scaler = None
 
-
     def on_stage_start(self, runner: IRunner) -> None:
         """Checks that the current stage has correct optimizer.
 
@@ -293,12 +292,10 @@ class AMPOptimizerCallback(Callback):
         """
         pass
 
-
     def on_batch_start(self, runner: IRunner) -> None:
         self.prev_autocast_state = torch.is_autocast_enabled()
         torch.set_autocast_enabled(True)
         torch.autocast_increment_nesting()
-
 
     def on_batch_end(self, runner: IRunner) -> None:
         """On batch end event
@@ -384,7 +381,6 @@ class AMPOptimizerCallback(Callback):
                 else "momentum"
             )
             runner.epoch_metrics[momentum_name] = momentum
-
 
     def on_stage_end(self, runner: IRunner) -> None:
         self.scaler = None

--- a/catalyst/core/callbacks/optimizer.py
+++ b/catalyst/core/callbacks/optimizer.py
@@ -322,18 +322,14 @@ class AMPOptimizerCallback(Callback):
 
         if need_gradient_step:
             self.grad_step(
-                optimizer=self._optimizer,
-                grad_clip_fn=self.grad_clip_fn,
+                optimizer=self._optimizer, grad_clip_fn=self.grad_clip_fn,
             )
 
             utils.maybe_recursive_call(self._optimizer, "zero_grad")
             self._accumulation_counter = 0
 
     def grad_step(
-        self,
-        *,
-        optimizer: Optimizer,
-        grad_clip_fn: Callable = None,
+        self, *, optimizer: Optimizer, grad_clip_fn: Callable = None,
     ) -> None:
         """Makes a gradient step for a given optimizer.
 

--- a/catalyst/core/callbacks/optimizer.py
+++ b/catalyst/core/callbacks/optimizer.py
@@ -2,6 +2,9 @@ from typing import Callable, Dict, List
 import logging
 import warnings
 
+import torch
+from torch.cuda.amp import GradScaler
+
 from catalyst import registry
 from catalyst.core import utils
 from catalyst.core.callback import Callback, CallbackNode, CallbackOrder
@@ -222,4 +225,164 @@ class OptimizerCallback(Callback):
             self._accumulation_counter = 0
 
 
-__all__ = ["OptimizerCallback"]
+class AMPOptimizerCallback(Callback):
+    """
+    Optimizer callback with native torch amp support.
+    TODO: Implement correct gradient clipping
+    TODO: Investigate whether we need invidual loss scaling
+    """
+
+    def __init__(
+        self,
+        metric_key: str = None,
+        optimizer_key: str = None,
+        accumulation_steps: int = 1,
+        grad_clip_params: Dict = None,
+        loss_key: str = None,
+    ):
+        """
+        Args:
+            loss_key (str): key to get loss from ``runner.batch_metrics``
+            optimizer_key (str): A key to take a optimizer in case
+                there are several of them and they are in a dictionary format.
+            accumulation_steps (int): number of steps before
+                ``model.zero_grad()``
+            grad_clip_params (dict): params for gradient clipping
+            decouple_weight_decay (bool): If True - decouple weight decay
+                regularization.
+        """
+        super().__init__(order=CallbackOrder.optimizer, node=CallbackNode.all)
+        assert metric_key is None or loss_key is None
+        if loss_key is not None:
+            warnings.warn(
+                "OptimizerCallback: "
+                "`loss_key` is now deprecated in favor `metric_key`",
+                stacklevel=2,
+            )
+        self.metric_key: str = metric_key or loss_key or "loss"
+        self.optimizer_key: str = optimizer_key
+
+        self.accumulation_steps: int = accumulation_steps
+        self._accumulation_counter: int = 0
+
+        grad_clip_params: dict = grad_clip_params or {}
+        self.grad_clip_fn = registry.GRAD_CLIPPER.get_from_params(
+            **grad_clip_params
+        )
+
+        # Initialized at on_state_start()
+        self.scaler = None
+
+
+    def on_stage_start(self, runner: IRunner) -> None:
+        """Checks that the current stage has correct optimizer.
+
+        Args:
+            runner(IRunner): current runner
+        """
+        self._optimizer = runner.get_attr(
+            key="optimizer", inner_key=self.optimizer_key
+        )
+        self.scaler = GradScaler()
+        assert self._optimizer is not None
+
+    def on_epoch_start(self, runner: IRunner) -> None:
+        """On epoch start event.
+
+        Args:
+            runner (IRunner): current runner
+        """
+        pass
+
+
+    def on_batch_start(self, runner: IRunner) -> None:
+        self.prev_autocast_state = torch.is_autocast_enabled()
+        torch.set_autocast_enabled(True)
+        torch.autocast_increment_nesting()
+
+
+    def on_batch_end(self, runner: IRunner) -> None:
+        """On batch end event
+
+        Args:
+            runner (IRunner): current runner
+        """
+
+        # Drop the cache when we exit to a nesting level
+        # that's outside any instance of autocast.
+        if torch.autocast_decrement_nesting() == 0:
+            torch.clear_autocast_cache()
+        torch.set_autocast_enabled(self.prev_autocast_state)
+
+        if not runner.is_train_loader:
+            return
+
+        loss = runner.batch_metrics[self.metric_key]
+
+        self._accumulation_counter += 1
+        need_gradient_step = (
+            self._accumulation_counter % self.accumulation_steps == 0
+        )
+
+        self.scaler.scale(loss).backward()
+
+        if need_gradient_step:
+            self.grad_step(
+                optimizer=self._optimizer,
+                grad_clip_fn=self.grad_clip_fn,
+            )
+
+            utils.maybe_recursive_call(self._optimizer, "zero_grad")
+            self._accumulation_counter = 0
+
+    def grad_step(
+        self,
+        *,
+        optimizer: Optimizer,
+        grad_clip_fn: Callable = None,
+    ) -> None:
+        """Makes a gradient step for a given optimizer.
+
+        Args:
+            optimizer (Optimizer): the optimizer
+            optimizer_wds (List[float]): list of weight decay parameters
+                for each param group
+            grad_clip_fn (Callable): function for gradient clipping
+        """
+        for group in zip(optimizer.param_groups):
+            if grad_clip_fn is not None:
+                grad_clip_fn(group["params"])
+
+        self.scaler.step(optimizer)
+        self.scaler.update()
+
+    def on_epoch_end(self, runner: IRunner) -> None:
+        """On epoch end event.
+
+        Args:
+            runner (IRunner): current runner
+        """
+
+        lr = self._optimizer.param_groups[0]["lr"]
+        lr_name = (
+            f"lr/{self.optimizer_key}"
+            if self.optimizer_key is not None
+            else "lr"
+        )
+        runner.epoch_metrics[lr_name] = lr
+
+        momentum = utils.get_optimizer_momentum(self._optimizer)
+        if momentum is not None:
+            momentum_name = (
+                f"momentum/{self.optimizer_key}"
+                if self.optimizer_key is not None
+                else "momentum"
+            )
+            runner.epoch_metrics[momentum_name] = momentum
+
+
+    def on_stage_end(self, runner: IRunner) -> None:
+        self.scaler = None
+
+
+__all__ = ["OptimizerCallback", "AMPOptimizerCallback"]

--- a/catalyst/core/callbacks/optimizer.py
+++ b/catalyst/core/callbacks/optimizer.py
@@ -301,7 +301,6 @@ class AMPOptimizerCallback(Callback):
         Args:
             runner (IRunner): current runner
         """
-
         # Drop the cache when we exit to a nesting level
         # that's outside any instance of autocast.
         if torch.autocast_decrement_nesting() == 0:
@@ -335,11 +334,8 @@ class AMPOptimizerCallback(Callback):
 
         Args:
             optimizer (Optimizer): the optimizer
-            optimizer_wds (List[float]): list of weight decay parameters
-                for each param group
             grad_clip_fn (Callable): function for gradient clipping
         """
-
         if grad_clip_fn is not None:
             # Unscales the gradients of
             # optimizer's assigned params in-place
@@ -358,7 +354,6 @@ class AMPOptimizerCallback(Callback):
         Args:
             runner (IRunner): current runner
         """
-
         lr = self._optimizer.param_groups[0]["lr"]
         lr_name = (
             f"lr/{self.optimizer_key}"
@@ -377,6 +372,11 @@ class AMPOptimizerCallback(Callback):
             runner.epoch_metrics[momentum_name] = momentum
 
     def on_stage_end(self, runner: IRunner) -> None:
+        """On stage end event.
+
+        Args:
+            runner (IRunner): current runner
+        """
         self.scaler = None
 
 

--- a/catalyst/core/callbacks/optimizer.py
+++ b/catalyst/core/callbacks/optimizer.py
@@ -290,7 +290,6 @@ class AMPOptimizerCallback(Callback):
         Args:
             runner (IRunner): current runner
         """
-
         self.prev_autocast_state = torch.is_autocast_enabled()
         torch.set_autocast_enabled(True)
         torch.autocast_increment_nesting()

--- a/catalyst/core/callbacks/optimizer.py
+++ b/catalyst/core/callbacks/optimizer.py
@@ -284,15 +284,13 @@ class AMPOptimizerCallback(Callback):
         self.scaler = GradScaler()
         assert self._optimizer is not None
 
-    def on_epoch_start(self, runner: IRunner) -> None:
-        """On epoch start event.
+    def on_batch_start(self, runner: IRunner) -> None:
+        """On batch start event
 
         Args:
             runner (IRunner): current runner
         """
-        pass
 
-    def on_batch_start(self, runner: IRunner) -> None:
         self.prev_autocast_state = torch.is_autocast_enabled()
         torch.set_autocast_enabled(True)
         torch.autocast_increment_nesting()

--- a/catalyst/core/callbacks/optimizer.py
+++ b/catalyst/core/callbacks/optimizer.py
@@ -3,7 +3,6 @@ import logging
 import warnings
 
 import torch
-from torch.cuda.amp import GradScaler
 
 from catalyst import registry
 from catalyst.core import utils
@@ -280,6 +279,8 @@ class AMPOptimizerCallback(Callback):
         Args:
             runner(IRunner): current runner
         """
+        from torch.cuda.amp import GradScaler
+
         self._optimizer = runner.get_attr(
             key="optimizer", inner_key=self.optimizer_key
         )

--- a/catalyst/core/runner.py
+++ b/catalyst/core/runner.py
@@ -819,7 +819,7 @@ class IRunner(ABC, IRunnerLegacy, FrozenClass):
                 from DataLoader.
         """
         if isinstance(batch, dict):
-            self.batch_size = next(iter(batch.values())).shape[0]
+            self.batch_size = len(next(iter(batch.values())))
         else:
             self.batch_size = len(batch[0])
         self.global_sample_step += self.batch_size

--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -530,9 +530,10 @@ class ConfigExperiment(IExperiment):
                 default_callbacks.append(("_tensorboard", TensorboardLogger))
 
             from catalyst.utils.distributed import check_amp_available
+
             is_amp_enabled = (
-                self.distributed_params.get("amp", False) and
-                check_amp_available()
+                self.distributed_params.get("amp", False)
+                and check_amp_available()
             )
             optimizer_cls = OptimizerCallback
             if is_amp_enabled:

--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -20,6 +20,7 @@ from catalyst.dl import (
     ExceptionCallback,
     MetricManagerCallback,
     OptimizerCallback,
+    AMPOptimizerCallback,
     SchedulerCallback,
     TensorboardLogger,
     TimerCallback,
@@ -528,10 +529,18 @@ class ConfigExperiment(IExperiment):
                 default_callbacks.append(("_saver", CheckpointCallback))
                 default_callbacks.append(("_tensorboard", TensorboardLogger))
 
+            from catalyst.utils.distributed import check_amp_available
+            is_amp_enabled = (
+                    self.distributed_params.get("amp", False) and check_amp_available()
+            )
+            optimizer_cls = OptimizerCallback
+            if is_amp_enabled:
+                optimizer_cls = AMPOptimizerCallback
+
             if self.stages_config[stage].get("criterion_params", {}):
                 default_callbacks.append(("_criterion", CriterionCallback))
             if self.stages_config[stage].get("optimizer_params", {}):
-                default_callbacks.append(("_optimizer", OptimizerCallback))
+                default_callbacks.append(("_optimizer", optimizer_cls))
             if self.stages_config[stage].get("scheduler_params", {}):
                 default_callbacks.append(("_scheduler", SchedulerCallback))
 

--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -14,8 +14,8 @@ from catalyst.dl import (
     AMPOptimizerCallback,
     BatchOverfitCallback,
     Callback,
-    CheckRunCallback,
     CheckpointCallback,
+    CheckRunCallback,
     ConsoleLogger,
     CriterionCallback,
     ExceptionCallback,
@@ -24,9 +24,9 @@ from catalyst.dl import (
     SchedulerCallback,
     TensorboardLogger,
     TimerCallback,
+    utils,
     ValidationManagerCallback,
     VerboseLogger,
-    utils,
 )
 from catalyst.dl.utils import check_callback_isinstance
 from catalyst.registry import (

--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -531,7 +531,8 @@ class ConfigExperiment(IExperiment):
 
             from catalyst.utils.distributed import check_amp_available
             is_amp_enabled = (
-                    self.distributed_params.get("amp", False) and check_amp_available()
+                self.distributed_params.get("amp", False) and
+                check_amp_available()
             )
             optimizer_cls = OptimizerCallback
             if is_amp_enabled:

--- a/catalyst/dl/experiment/config.py
+++ b/catalyst/dl/experiment/config.py
@@ -11,22 +11,22 @@ from torch.utils.data import DataLoader
 from catalyst.core import IExperiment
 from catalyst.data import Augmentor, AugmentorCompose
 from catalyst.dl import (
+    AMPOptimizerCallback,
     BatchOverfitCallback,
     Callback,
-    CheckpointCallback,
     CheckRunCallback,
+    CheckpointCallback,
     ConsoleLogger,
     CriterionCallback,
     ExceptionCallback,
     MetricManagerCallback,
     OptimizerCallback,
-    AMPOptimizerCallback,
     SchedulerCallback,
     TensorboardLogger,
     TimerCallback,
-    utils,
     ValidationManagerCallback,
     VerboseLogger,
+    utils,
 )
 from catalyst.dl.utils import check_callback_isinstance
 from catalyst.registry import (

--- a/catalyst/dl/experiment/supervised.py
+++ b/catalyst/dl/experiment/supervised.py
@@ -3,10 +3,10 @@ from collections import OrderedDict
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 
 from catalyst.dl import (
+    AMPOptimizerCallback,
     Callback,
     CriterionCallback,
     OptimizerCallback,
-    AMPOptimizerCallback,
     SchedulerCallback,
 )
 from catalyst.dl.experiment.experiment import Experiment

--- a/catalyst/dl/experiment/supervised.py
+++ b/catalyst/dl/experiment/supervised.py
@@ -58,8 +58,10 @@ class SupervisedExperiment(Experiment):
         callbacks = super().get_callbacks(stage=stage) or OrderedDict()
 
         from catalyst.utils.distributed import check_amp_available
+
         is_amp_enabled = (
-            self.distributed_params.get("amp", False) and check_amp_available()
+            self.distributed_params.get("amp", False)
+            and check_amp_available()
         )
         optimizer_cls = OptimizerCallback
         if is_amp_enabled:

--- a/catalyst/dl/experiment/supervised.py
+++ b/catalyst/dl/experiment/supervised.py
@@ -60,8 +60,7 @@ class SupervisedExperiment(Experiment):
         from catalyst.utils.distributed import check_amp_available
 
         is_amp_enabled = (
-            self.distributed_params.get("amp", False)
-            and check_amp_available()
+            self.distributed_params.get("amp", False) and check_amp_available()
         )
         optimizer_cls = OptimizerCallback
         if is_amp_enabled:

--- a/catalyst/utils/components.py
+++ b/catalyst/utils/components.py
@@ -94,13 +94,14 @@ def process_components(
         if is_apex_available:
             import apex
 
+            if syncbn:
+                model = apex.parallel.convert_syncbn_model(model)
+
             model, optimizer = initialize_apex(
                 model, optimizer, **distributed_params
             )
             model = apex.parallel.DistributedDataParallel(model)
 
-            if syncbn:
-                model = apex.parallel.convert_syncbn_model(model)
         else:
             model = nn.parallel.DistributedDataParallel(
                 model, device_ids=[local_rank], output_device=local_rank

--- a/catalyst/utils/components.py
+++ b/catalyst/utils/components.py
@@ -14,11 +14,12 @@ from catalyst.tools.typing import (
     Scheduler,
 )
 from catalyst.utils.distributed import (
+    check_amp_available,
     check_apex_available,
     check_ddp_wrapped,
     get_distributed_params,
     get_rank,
-    initialize_apex, check_amp_available,
+    initialize_apex,
 )
 from catalyst.utils.misc import maybe_recursive_call
 from catalyst.utils.torch import get_device
@@ -80,8 +81,10 @@ def process_components(
     )
 
     if is_apex_enabled and is_amp_enabled:
-        raise ValueError("Both NVidia Apex and Torch.Amp are enabled. "
-                         "You must choose only one mixed precision backend")
+        raise ValueError(
+            "Both NVidia Apex and Torch.Amp are enabled. "
+            "You must choose only one mixed precision backend"
+        )
     model: Model = maybe_recursive_call(model, "to", device=device)
 
     if check_ddp_wrapped(model):

--- a/catalyst/utils/components.py
+++ b/catalyst/utils/components.py
@@ -110,7 +110,7 @@ def process_components(
             model = apex.parallel.DistributedDataParallel(model)
         else:
             if is_amp_enabled:
-               pass
+                pass
 
             if syncbn:
                 model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)

--- a/catalyst/utils/distributed.py
+++ b/catalyst/utils/distributed.py
@@ -48,6 +48,15 @@ def check_apex_available() -> bool:
         return False and env_apex
 
 
+def check_amp_available() -> bool:
+    """Checks if torch.amp is available."""
+    major, minor = torch.__version__.split(".")[:2]
+    major = int(major)
+    minor = int(minor)
+    # torch.amp available since version 1.6 and above
+    return (major >= 1 and minor >= 6) or major > 1
+
+
 def check_torch_distributed_initialized() -> bool:
     """Checks if torch.distributed is available and initialized."""
     return (
@@ -277,6 +286,7 @@ def is_apex_available() -> bool:
 __all__ = [
     "check_ddp_wrapped",
     "check_apex_available",
+    "check_amp_available",
     "check_torch_distributed_initialized",
     "check_slurm_available",
     "assert_fp16_available",

--- a/catalyst/utils/distributed.py
+++ b/catalyst/utils/distributed.py
@@ -12,6 +12,7 @@ import deprecation
 import torch
 from torch import nn
 import torch.distributed
+from packaging.version import parse, Version
 
 from catalyst import __version__
 from catalyst.utils.misc import get_fn_default_params
@@ -50,11 +51,7 @@ def check_apex_available() -> bool:
 
 def check_amp_available() -> bool:
     """Checks if torch.amp is available."""
-    major, minor = torch.__version__.split(".")[:2]
-    major = int(major)
-    minor = int(minor)
-    # torch.amp available since version 1.6 and above
-    return (major >= 1 and minor >= 6) or major > 1
+    return parse(torch.__version__) >= Version("1.6.0")
 
 
 def check_torch_distributed_initialized() -> bool:

--- a/catalyst/utils/distributed.py
+++ b/catalyst/utils/distributed.py
@@ -126,10 +126,14 @@ def get_distributed_mean(value: Union[float, torch.Tensor]):
     """Computes distributed mean among all nodes."""
     if check_torch_distributed_initialized():
         # Fix for runtime warning:
-        # To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or
-        # sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
+        # To copy construct from a tensor, it is recommended to use 
+        # sourceTensor.clone().detach() or 
+        # sourceTensor.clone().detach().requires_grad_(True), 
+        # rather than torch.tensor(sourceTensor).
         if torch.is_tensor(value):
-            value = value.clone().detach().to(device=f"cuda:{torch.cuda.current_device()}")
+            value = value.clone().detach().to(
+                device=f"cuda:{torch.cuda.current_device()}"
+            )
         else:
             value = torch.tensor(
                 value,

--- a/catalyst/utils/distributed.py
+++ b/catalyst/utils/distributed.py
@@ -125,12 +125,18 @@ def get_rank() -> int:
 def get_distributed_mean(value: Union[float, torch.Tensor]):
     """Computes distributed mean among all nodes."""
     if check_torch_distributed_initialized():
-        value = torch.tensor(
-            value,
-            dtype=torch.float,
-            device=f"cuda:{torch.cuda.current_device()}",
-            requires_grad=False,
-        )
+        # Fix for runtime warning:
+        # To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or
+        # sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
+        if torch.is_tensor(value):
+            value = value.clone().detach().to(device=f"cuda:{torch.cuda.current_device()}")
+        else:
+            value = torch.tensor(
+                value,
+                dtype=torch.float,
+                device=f"cuda:{torch.cuda.current_device()}",
+                requires_grad=False,
+            )
         torch.distributed.all_reduce(value)
         value = float(value.item() / torch.distributed.get_world_size())
     return value

--- a/catalyst/utils/distributed.py
+++ b/catalyst/utils/distributed.py
@@ -8,11 +8,11 @@ import socket
 import subprocess
 
 import deprecation
+from packaging.version import parse, Version
 
 import torch
 from torch import nn
 import torch.distributed
-from packaging.version import parse, Version
 
 from catalyst import __version__
 from catalyst.utils.misc import get_fn_default_params

--- a/catalyst/utils/distributed.py
+++ b/catalyst/utils/distributed.py
@@ -126,13 +126,15 @@ def get_distributed_mean(value: Union[float, torch.Tensor]):
     """Computes distributed mean among all nodes."""
     if check_torch_distributed_initialized():
         # Fix for runtime warning:
-        # To copy construct from a tensor, it is recommended to use 
-        # sourceTensor.clone().detach() or 
-        # sourceTensor.clone().detach().requires_grad_(True), 
+        # To copy construct from a tensor, it is recommended to use
+        # sourceTensor.clone().detach() or
+        # sourceTensor.clone().detach().requires_grad_(True),
         # rather than torch.tensor(sourceTensor).
         if torch.is_tensor(value):
-            value = value.clone().detach().to(
-                device=f"cuda:{torch.cuda.current_device()}"
+            value = (
+                value.clone()
+                .detach()
+                .to(device=f"cuda:{torch.cuda.current_device()}")
             )
         else:
             value = torch.tensor(


### PR DESCRIPTION
## Before submitting

- [x] Was this discussed/approved via a Github issue? (https://github.com/catalyst-team/catalyst/issues/740)
- [ ] Did you read the [contribution guide](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md)?
- [ ] Did you check the code style? `catalyst-make-codestyle && catalyst-check-codestyle` (`pip install -U catalyst-codestyle`).
- [ ] Did you make sure to update the docs? We use Google format for all the methods and classes.
- [ ] Did you check the docs with `make check-docs`?
- [ ] Did you write any new necessary tests?
- [ ] Did you add your new functionality to the docs?
- [ ] Did you update the [CHANGELOG](https://github.com/catalyst-team/catalyst/CHANGELOG.md)?
- [x] **You can use 'Login as guest' to see Teamcity build logs.**

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->


## Description

This PR brings support of `torch.cuda.amp` (https://pytorch.org/docs/stable/notes/amp_examples.html) to catalyst, which is faster replacement of NVidia Apex. Instead of `apex: True` we use `amp: True` and that's all.

## Related Issue

https://github.com/catalyst-team/catalyst/issues/740

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

<!-- Thank you for your contribution! -->