### PR TITLE
Merge AMPOptimizerCallback and OptimizerCallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,7 +842,7 @@ runner.train(
     logdir="./logdir",
     num_epochs=3,
     callbacks=[dl.AccuracyCallback(num_classes=num_classes)],
-    fp16=dict(opt_level="O1"),
+    fp16=dict(apex=True, opt_level="O1"),
 )
 ```
 </p>

--- a/catalyst/callbacks/__init__.py
+++ b/catalyst/callbacks/__init__.py
@@ -39,7 +39,6 @@ from catalyst.callbacks.metric import (
 from catalyst.callbacks.optimizer import (
     IOptimizerCallback,
     OptimizerCallback,
-    AMPOptimizerCallback,
 )
 from catalyst.callbacks.periodic_loader import PeriodicLoaderCallback
 from catalyst.callbacks.scheduler import (

--- a/catalyst/callbacks/optimizer.py
+++ b/catalyst/callbacks/optimizer.py
@@ -42,27 +42,29 @@ class OptimizerCallback(IOptimizerCallback):
     """Optimizer callback, abstraction over optimizer step."""
 
     def __init__(
-        self,
-        metric_key: str = None,
-        optimizer_key: str = None,
-        accumulation_steps: int = 1,
-        grad_clip_params: Dict = None,
-        decouple_weight_decay: bool = True,
-        loss_key: str = None,
-        use_fast_zero_grad: bool = False,
-        xla_barrier: bool = True,
+            self,
+            metric_key: str = None,
+            optimizer_key: str = None,
+            accumulation_steps: int = 1,
+            grad_clip_params: Dict = None,
+            decouple_weight_decay: bool = False,
+            loss_key: str = None,
+            use_fast_zero_grad: bool = False,
+            xla_barrier: bool = True,
+            use_amp: bool = None,
+            use_apex: bool = None
     ):
         """
         Args:
             loss_key: key to get loss from ``runner.batch_metrics``
             optimizer_key: A key to take a optimizer in case
                 there are several of them and they are in a dictionary format.
-            accumulation_steps: number of steps before
-                ``model.zero_grad()``
-            grad_clip_params: params for gradient clipping
+            accumulation_steps: number of steps before ``model.zero_grad()``
+            grad_clip_params: params for gradient clipping, example:
+                ``{'func': 'clip_grad_norm_', 'max_norm': 1, norm_type': 2}``
             decouple_weight_decay: If ``True`` - decouple weight decay
-                regularization.
-            use_fast_zero_grad: boost ``optiomizer.zero_grad()``,
+                regularization, default is ``False``.
+            use_fast_zero_grad: boost ``optimizer.zero_grad()``,
                 default is ``False``.
             xla_barrier: barrier option for xla. Here you can find
                 more about usage of `barrier flag
@@ -71,8 +73,12 @@ class OptimizerCallback(IOptimizerCallback):
                 and `examples
                 <https://pytorch.org/xla/release/1.5/index.html#
                 running-on-a-single-xla-device>`_.
-
                 Default is ``True``.
+            use_amp: whether to use native pytorch AMP,
+                if None will be set based on runner.experiment.distributed_params on stage start
+            use_apex: whether to use apex,
+                if None will be set based on runner.experiment.distributed_params on stage start
+
         """
         super().__init__(order=CallbackOrder.optimizer, node=CallbackNode.all)
         assert metric_key is None or loss_key is None
@@ -88,79 +94,116 @@ class OptimizerCallback(IOptimizerCallback):
         self.accumulation_steps: int = accumulation_steps
         self._accumulation_counter: int = 0
 
+        if use_apex and use_amp:
+            raise ValueError(
+                "OptimizerCallback: ``use_amp==True`` and ``use_apex==True`` "
+                "You must choose only one mixed precision backend"
+            )
+
+        self.use_amp = use_amp
+        self.use_apex = use_apex
+
+        # If use_amp==True scaler is initialized at on_stage_start()
+        self.scaler = None
+
         grad_clip_params: dict = grad_clip_params or {}
         self.grad_clip_fn = registry.GRAD_CLIPPER.get_from_params(
             **grad_clip_params
         )
 
         self.decouple_weight_decay = decouple_weight_decay
-        self._optimizer_wd: List[float] = [0.0]
+        self._optimizer_wds: List = None
         self._optimizer_step_fn: Callable = None
         self.is_xla = False
         self.use_fast_zero_grad = use_fast_zero_grad
         self.use_xla_barrier = xla_barrier
 
-    def _optimizer_step(self, optimizer: Optimizer) -> None:
+    def _optimizer_step(self) -> None:
         """CPU and GPU optimization step.
-
-        Args:
-            optimizer: optimizer object
         """
-        optimizer.step()
+        self._optimizer.step()
 
-    def _optimizer_step_tpu(self, optimizer: Optimizer) -> None:
+    def _optimizer_step_amp(self) -> None:
+        """Optimization step with pytorch native amp
+        """
+        self.scaler.step(self._optimizer)
+        self.scaler.update()
+
+    def _optimizer_step_tpu(self) -> None:
         """TPU optimization step.
-
-        Args:
-            optimizer: optimizer object
         """
         if self.use_xla_barrier:
-            xm.optimizer_step(optimizer, barrier=True)
+            xm.optimizer_step(self._optimizer, barrier=True)
         else:
-            xm.optimizer_step(optimizer)
+            xm.optimizer_step(self._optimizer)
 
     def grad_step(
         self,
         *,
         optimizer: Optimizer,
-        optimizer_wds: List[float] = 0,
         grad_clip_fn: Callable = None,
     ) -> None:
         """Makes a gradient step for a given optimizer.
 
         Args:
             optimizer: the optimizer
-            optimizer_wds: list of weight decay parameters
-                for each param group
             grad_clip_fn: function for gradient clipping
         """
-        for group, wd in zip(optimizer.param_groups, optimizer_wds):
-            if wd > 0:
+        if self.decouple_weight_decay:
+            for group, wd in zip(optimizer.param_groups, self._optimizer_wds):
                 for param in group["params"]:
-                    param.data = param.data.add(
-                        other=param.data, alpha=-wd * group["lr"]
-                    )
-            if grad_clip_fn is not None:
+                    param.data = param.data.add(other=param.data,
+                                                alpha=-wd * group["lr"])
+
+        if grad_clip_fn is not None:
+            if self.use_amp:
+                self.scaler.unscale_(optimizer)
+            for group in optimizer.param_groups:
                 grad_clip_fn(group["params"])
+
         # optimize parameters
-        self._optimizer_step_fn(optimizer)
+        self._optimizer_step_fn()
 
     def on_stage_start(self, runner: "IRunner") -> None:
-        """Checks that the current stage has correct optimizer.
+        """Resolve amp/apex settings, prepare optimizer and scaler
 
         Args:
             runner(IRunner): current runner
         """
+        if self.use_amp is None and runner.experiment is not None:
+            self.use_amp = runner.experiment.distributed_params.get("amp", False)
+        else:
+            self.use_amp = False
+
+        if self.use_apex is None and runner.experiment is not None:
+            self.use_apex = runner.experiment.distributed_params.get("apex", False)
+        else:
+            self.use_apex = False
+
         self._optimizer = get_attr(
             runner, key="optimizer", inner_key=self.optimizer_key
         )
+
         # device based optimization step
         if runner.device.type == "xla":
             self._optimizer_step_fn = self._optimizer_step_tpu
+        elif self.use_amp:
+            self._optimizer_step_fn = self._optimizer_step_amp
         else:
             self._optimizer_step_fn = self._optimizer_step
 
+        if hasattr(self._optimizer, "_amp_stash") and not self.use_apex:
+            warnings.warn(
+                "`_amp_stash` is found in `self._optimizer`:, "
+                "but `use_apex` is False",
+                stacklevel=2,
+            )
+
         assert self._optimizer is not None
+
+        if self.use_amp:
+            from torch.cuda.amp import GradScaler
+            self.scaler = GradScaler()
 
     def on_epoch_start(self, runner: "IRunner") -> None:
         """On epoch start event.
@@ -169,14 +212,23 @@ class OptimizerCallback(IOptimizerCallback):
             runner: current runner
         """
         if self.decouple_weight_decay:
-            self._optimizer_wd = [
+            self._optimizer_wds = [
                 group.get("weight_decay", 0.0)
                 for group in self._optimizer.param_groups
             ]
             for i in range(len(self._optimizer.param_groups)):
                 self._optimizer.param_groups[i]["weight_decay"] = 0.0
-        else:
-            self._optimizer_wd = [0.0] * len(self._optimizer.param_groups)
+
+    def on_batch_start(self, runner: "IRunner") -> None:
+        """On batch start event
+
+        Args:
+            runner: current runner
+        """
+        if self.use_amp:
+            self.prev_autocast_state = torch.is_autocast_enabled()
+            torch.set_autocast_enabled(True)
+            torch.autocast_increment_nesting()
 
     def on_batch_end(self, runner: "IRunner") -> None:
         """On batch end event
@@ -184,6 +236,13 @@ class OptimizerCallback(IOptimizerCallback):
         Args:
             runner: current runner
         """
+        if self.use_amp:
+            # Drop the cache when we exit to a nesting level
+            # that's outside any instance of autocast.
+            if torch.autocast_decrement_nesting() == 0:
+                torch.clear_autocast_cache()
+            torch.set_autocast_enabled(self.prev_autocast_state)
+
         if not runner.is_train_loader:
             return
 
@@ -194,12 +253,8 @@ class OptimizerCallback(IOptimizerCallback):
             self._accumulation_counter % self.accumulation_steps == 0
         )
 
-        # This is very hacky check whether we have AMP optimizer and this may
-        # change in future.
-        # But alternative solution is to have AmpOptimizerCallback.
-        # or expose another c'tor argument.
         # @TODO: speedup with re-definition ``on_stage_start``
-        if hasattr(self._optimizer, "_amp_stash"):
+        if self.use_apex:
             from apex import amp
 
             # Need to set ``delay_unscale``
@@ -210,13 +265,14 @@ class OptimizerCallback(IOptimizerCallback):
                 loss, self._optimizer, delay_unscale=delay_unscale
             ) as scaled_loss:
                 scaled_loss.backward()
+        elif self.use_amp:
+            self.scaler.scale(loss).backward()
         else:
             loss.backward()
 
         if need_gradient_step:
             self.grad_step(
                 optimizer=self._optimizer,
-                optimizer_wds=self._optimizer_wd,
                 grad_clip_fn=self.grad_clip_fn,
             )
             if not self.use_fast_zero_grad:
@@ -232,156 +288,9 @@ class OptimizerCallback(IOptimizerCallback):
             runner: current runner
         """
         if self.decouple_weight_decay:
-            for i, wd in enumerate(self._optimizer_wd):
+            for i, wd in enumerate(self._optimizer_wds):
                 self._optimizer.param_groups[i]["weight_decay"] = wd
 
-        lr = self._optimizer.param_groups[0]["lr"]
-        lr_name = (
-            f"lr/{self.optimizer_key}"
-            if self.optimizer_key is not None
-            else "lr"
-        )
-        runner.epoch_metrics[lr_name] = lr
-
-        momentum = get_optimizer_momentum(self._optimizer)
-        if momentum is not None:
-            momentum_name = (
-                f"momentum/{self.optimizer_key}"
-                if self.optimizer_key is not None
-                else "momentum"
-            )
-            runner.epoch_metrics[momentum_name] = momentum
-
-
-class AMPOptimizerCallback(IOptimizerCallback):
-    """
-    Optimizer callback with native torch amp support.
-    """
-
-    def __init__(
-        self,
-        metric_key: str = None,
-        optimizer_key: str = None,
-        accumulation_steps: int = 1,
-        grad_clip_params: Dict = None,
-        loss_key: str = None,
-    ):
-        """
-        Args:
-            loss_key: key to get loss from ``runner.batch_metrics``
-            optimizer_key: A key to take a optimizer in case
-                there are several of them and they are in a dictionary format.
-            accumulation_steps: number of steps before
-                ``model.zero_grad()``
-            grad_clip_params: params for gradient clipping
-            decouple_weight_decay: If True - decouple weight decay
-                regularization.
-        """
-        super().__init__(order=CallbackOrder.optimizer, node=CallbackNode.all)
-        assert metric_key is None or loss_key is None
-        if loss_key is not None:
-            warnings.warn(
-                "OptimizerCallback: "
-                "`loss_key` is now deprecated in favor `metric_key`",
-                stacklevel=2,
-            )
-        self.metric_key: str = metric_key or loss_key or "loss"
-        self.optimizer_key: str = optimizer_key
-
-        self.accumulation_steps: int = accumulation_steps
-        self._accumulation_counter: int = 0
-
-        grad_clip_params: dict = grad_clip_params or {}
-        self.grad_clip_fn = registry.GRAD_CLIPPER.get_from_params(
-            **grad_clip_params
-        )
-
-        # Initialized at on_state_start()
-        self.scaler = None
-
-    def grad_step(
-        self, *, optimizer: Optimizer, grad_clip_fn: Callable = None,
-    ) -> None:
-        """Makes a gradient step for a given optimizer.
-
-        Args:
-            optimizer: the optimizer
-            grad_clip_fn: function for gradient clipping
-        """
-        if grad_clip_fn is not None:
-            # Unscales the gradients of
-            # optimizer's assigned params in-place
-            self.scaler.unscale_(optimizer)
-            for group in optimizer.param_groups:
-                # Since the gradients of optimizer's
-                # assigned params are unscaled, clips as usual:
-                grad_clip_fn(group["params"])
-
-        self.scaler.step(optimizer)
-        self.scaler.update()
-
-    def on_stage_start(self, runner: "IRunner") -> None:
-        """Checks that the current stage has correct optimizer.
-
-        Args:
-            runner(IRunner): current runner
-        """
-        from torch.cuda.amp import GradScaler
-
-        self._optimizer = get_attr(
-            runner, key="optimizer", inner_key=self.optimizer_key
-        )
-        self.scaler = GradScaler()
-        assert self._optimizer is not None
-
-    def on_batch_start(self, runner: "IRunner") -> None:
-        """On batch start event
-
-        Args:
-            runner: current runner
-        """
-        self.prev_autocast_state = torch.is_autocast_enabled()
-        torch.set_autocast_enabled(True)
-        torch.autocast_increment_nesting()
-
-    def on_batch_end(self, runner: "IRunner") -> None:
-        """On batch end event
-
-        Args:
-            runner: current runner
-        """
-        # Drop the cache when we exit to a nesting level
-        # that's outside any instance of autocast.
-        if torch.autocast_decrement_nesting() == 0:
-            torch.clear_autocast_cache()
-        torch.set_autocast_enabled(self.prev_autocast_state)
-
-        if not runner.is_train_loader:
-            return
-
-        loss = runner.batch_metrics[self.metric_key]
-
-        self._accumulation_counter += 1
-        need_gradient_step = (
-            self._accumulation_counter % self.accumulation_steps == 0
-        )
-
-        self.scaler.scale(loss).backward()
-
-        if need_gradient_step:
-            self.grad_step(
-                optimizer=self._optimizer, grad_clip_fn=self.grad_clip_fn,
-            )
-
-            maybe_recursive_call(self._optimizer, "zero_grad")
-            self._accumulation_counter = 0
-
-    def on_epoch_end(self, runner: "IRunner") -> None:
-        """On epoch end event.
-
-        Args:
-            runner: current runner
-        """
         lr = self._optimizer.param_groups[0]["lr"]
         lr_name = (
             f"lr/{self.optimizer_key}"
@@ -405,27 +314,11 @@ class AMPOptimizerCallback(IOptimizerCallback):
         Args:
             runner: current runner
         """
-        self.scaler = None
-
-
-# @TODO: add OptimizerCallback autocreation
-# def OptimizerCallback(*args, **kwargs):
-#     """
-#     Optimizer callback factory-wrapper to select required OptimizerCallback
-#     automatically.
-#     """
-#     is_amp_enabled = (
-#         os.getenv("USE_AMP", "0") == "1" and utils.check_amp_available()
-#     )
-#
-#     optimizer_callback = AMPOptimizerCallback(*args, **kwargs) \
-#         if is_amp_enabled \
-#         else OptimizerCallback(*args, **kwargs)
-#     return optimizer_callback
+        if self.use_amp:
+            self.scaler = None
 
 
 __all__ = [
     "IOptimizerCallback",
-    "AMPOptimizerCallback",
     "OptimizerCallback",
 ]

--- a/catalyst/callbacks/optimizer.py
+++ b/catalyst/callbacks/optimizer.py
@@ -52,7 +52,7 @@ class OptimizerCallback(IOptimizerCallback):
         use_fast_zero_grad: bool = False,
         xla_barrier: bool = True,
         use_amp: bool = None,
-        use_apex: bool = None
+        use_apex: bool = None,
     ):
         """
         Args:
@@ -138,7 +138,7 @@ class OptimizerCallback(IOptimizerCallback):
             xm.optimizer_step(self._optimizer)
 
     def grad_step(
-            self, *, optimizer: Optimizer, grad_clip_fn: Callable = None
+        self, *, optimizer: Optimizer, grad_clip_fn: Callable = None
     ) -> None:
         """Makes a gradient step for a given optimizer.
 
@@ -170,8 +170,8 @@ class OptimizerCallback(IOptimizerCallback):
         """
         if self.use_amp is None and runner.experiment is not None:
             self.use_amp = runner.experiment.distributed_params.get(
-                    "amp", False
-                )
+                "amp", False
+            )
         else:
             self.use_amp = False
 

--- a/catalyst/callbacks/optimizer.py
+++ b/catalyst/callbacks/optimizer.py
@@ -42,17 +42,17 @@ class OptimizerCallback(IOptimizerCallback):
     """Optimizer callback, abstraction over optimizer step."""
 
     def __init__(
-            self,
-            metric_key: str = None,
-            optimizer_key: str = None,
-            accumulation_steps: int = 1,
-            grad_clip_params: Dict = None,
-            decouple_weight_decay: bool = False,
-            loss_key: str = None,
-            use_fast_zero_grad: bool = False,
-            xla_barrier: bool = True,
-            use_amp: bool = None,
-            use_apex: bool = None
+        self,
+        metric_key: str = None,
+        optimizer_key: str = None,
+        accumulation_steps: int = 1,
+        grad_clip_params: Dict = None,
+        decouple_weight_decay: bool = False,
+        loss_key: str = None,
+        use_fast_zero_grad: bool = False,
+        xla_barrier: bool = True,
+        use_amp: bool = None,
+        use_apex: bool = None
     ):
         """
         Args:
@@ -138,10 +138,7 @@ class OptimizerCallback(IOptimizerCallback):
             xm.optimizer_step(self._optimizer)
 
     def grad_step(
-        self,
-        *,
-        optimizer: Optimizer,
-        grad_clip_fn: Callable = None,
+            self, *, optimizer: Optimizer, grad_clip_fn: Callable = None
     ) -> None:
         """Makes a gradient step for a given optimizer.
 
@@ -152,8 +149,9 @@ class OptimizerCallback(IOptimizerCallback):
         if self.decouple_weight_decay:
             for group, wd in zip(optimizer.param_groups, self._optimizer_wds):
                 for param in group["params"]:
-                    param.data = param.data.add(other=param.data,
-                                                alpha=-wd * group["lr"])
+                    param.data = param.data.add(
+                        other=param.data, alpha=-wd * group["lr"]
+                    )
 
         if grad_clip_fn is not None:
             if self.use_amp:
@@ -171,14 +169,16 @@ class OptimizerCallback(IOptimizerCallback):
             runner(IRunner): current runner
         """
         if self.use_amp is None and runner.experiment is not None:
-            self.use_amp = \
-                runner.experiment.distributed_params.get("amp", False)
+            self.use_amp = runner.experiment.distributed_params.get(
+                    "amp", False
+                )
         else:
             self.use_amp = False
 
         if self.use_apex is None and runner.experiment is not None:
-            self.use_apex = \
-                runner.experiment.distributed_params.get("apex", False)
+            self.use_apex = runner.experiment.distributed_params.get(
+                "apex", False
+            )
         else:
             self.use_apex = False
 
@@ -205,6 +205,7 @@ class OptimizerCallback(IOptimizerCallback):
 
         if self.use_amp:
             from torch.cuda.amp import GradScaler
+
             self.scaler = GradScaler()
 
     def on_epoch_start(self, runner: "IRunner") -> None:
@@ -274,8 +275,7 @@ class OptimizerCallback(IOptimizerCallback):
 
         if need_gradient_step:
             self.grad_step(
-                optimizer=self._optimizer,
-                grad_clip_fn=self.grad_clip_fn,
+                optimizer=self._optimizer, grad_clip_fn=self.grad_clip_fn,
             )
             if not self.use_fast_zero_grad:
                 maybe_recursive_call(self._optimizer, "zero_grad")

--- a/catalyst/callbacks/optimizer.py
+++ b/catalyst/callbacks/optimizer.py
@@ -74,10 +74,10 @@ class OptimizerCallback(IOptimizerCallback):
                 <https://pytorch.org/xla/release/1.5/index.html#
                 running-on-a-single-xla-device>`_.
                 Default is ``True``.
-            use_amp: whether to use native pytorch AMP,
-                if None will be set based on runner.experiment.distributed_params on stage start
-            use_apex: whether to use apex,
-                if None will be set based on runner.experiment.distributed_params on stage start
+            use_amp: whether to use native pytorch AMP, if None will be set
+                based on runner.experiment.distributed_params on stage start
+            use_apex: whether to use apex, if None will be set
+                based on runner.experiment.distributed_params on stage start
 
         """
         super().__init__(order=CallbackOrder.optimizer, node=CallbackNode.all)
@@ -171,12 +171,14 @@ class OptimizerCallback(IOptimizerCallback):
             runner(IRunner): current runner
         """
         if self.use_amp is None and runner.experiment is not None:
-            self.use_amp = runner.experiment.distributed_params.get("amp", False)
+            self.use_amp = \
+                runner.experiment.distributed_params.get("amp", False)
         else:
             self.use_amp = False
 
         if self.use_apex is None and runner.experiment is not None:
-            self.use_apex = runner.experiment.distributed_params.get("apex", False)
+            self.use_apex = \
+                runner.experiment.distributed_params.get("apex", False)
         else:
             self.use_apex = False
 

--- a/catalyst/callbacks/tests/test_optimizer_callback.py
+++ b/catalyst/callbacks/tests/test_optimizer_callback.py
@@ -14,6 +14,7 @@ class DummyRunner:
         self.batch_metrics = {"loss": loss_value}
         self.is_train_loader = True
         self.optimizer = optimizer
+        self.experiment = None
         self.device = torch.device("cpu")
 
     def get_attr(self, key, *args, **kwargs):

--- a/catalyst/core/runner.py
+++ b/catalyst/core/runner.py
@@ -371,7 +371,7 @@ class IRunner(ABC, ICallback, IRunnerLegacy):
         """
         self._device = None
         self._model = None
-        self.experiment = None
+        self.experiment: IExperiment = None
         self._prepare_inner_state(model=model, device=device)
 
     def _prepare_inner_state(

--- a/catalyst/experiments/config.py
+++ b/catalyst/experiments/config.py
@@ -17,10 +17,7 @@ from catalyst.callbacks.logging import (
     VerboseLogger,
 )
 from catalyst.callbacks.metric import MetricManagerCallback
-from catalyst.callbacks.optimizer import (
-    IOptimizerCallback,
-    OptimizerCallback,
-)
+from catalyst.callbacks.optimizer import IOptimizerCallback, OptimizerCallback
 from catalyst.callbacks.scheduler import ISchedulerCallback, SchedulerCallback
 from catalyst.callbacks.timer import TimerCallback
 from catalyst.callbacks.validation import ValidationManagerCallback

--- a/catalyst/experiments/config.py
+++ b/catalyst/experiments/config.py
@@ -18,7 +18,6 @@ from catalyst.callbacks.logging import (
 )
 from catalyst.callbacks.metric import MetricManagerCallback
 from catalyst.callbacks.optimizer import (
-    AMPOptimizerCallback,
     IOptimizerCallback,
     OptimizerCallback,
 )
@@ -537,12 +536,7 @@ class ConfigExperiment(IExperiment):
         # default_callbacks = [(Name, InterfaceClass, InstanceFactory)]
         default_callbacks = []
 
-        is_amp_enabled = (
-            self.distributed_params.get("amp", False) and check_amp_available()
-        )
-        optimizer_cls = (
-            AMPOptimizerCallback if is_amp_enabled else OptimizerCallback
-        )
+        optimizer_cls = OptimizerCallback
 
         if self._verbose:
             default_callbacks.append(("_verbose", None, VerboseLogger))

--- a/catalyst/experiments/supervised.py
+++ b/catalyst/experiments/supervised.py
@@ -4,7 +4,6 @@ from torch.optim.lr_scheduler import ReduceLROnPlateau
 
 from catalyst.callbacks.criterion import CriterionCallback
 from catalyst.callbacks.optimizer import (
-    AMPOptimizerCallback,
     IOptimizerCallback,
     OptimizerCallback,
 )
@@ -61,12 +60,7 @@ class SupervisedExperiment(Experiment):
         # default_callbacks = [(Name, InterfaceClass, InstanceFactory)]
         default_callbacks = []
 
-        is_amp_enabled = (
-            self.distributed_params.get("amp", False) and check_amp_available()
-        )
-        optimizer_cls = (
-            AMPOptimizerCallback if is_amp_enabled else OptimizerCallback
-        )
+        optimizer_cls = OptimizerCallback
 
         if not stage.startswith("infer"):
             if self._criterion is not None and isinstance(

--- a/catalyst/experiments/supervised.py
+++ b/catalyst/experiments/supervised.py
@@ -3,10 +3,7 @@ from collections import OrderedDict
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 
 from catalyst.callbacks.criterion import CriterionCallback
-from catalyst.callbacks.optimizer import (
-    IOptimizerCallback,
-    OptimizerCallback,
-)
+from catalyst.callbacks.optimizer import IOptimizerCallback, OptimizerCallback
 from catalyst.callbacks.scheduler import ISchedulerCallback, SchedulerCallback
 from catalyst.core.callback import Callback
 from catalyst.core.functional import check_callback_isinstance

--- a/catalyst/runners/runner.py
+++ b/catalyst/runners/runner.py
@@ -428,7 +428,7 @@ class Runner(IStageBasedRunner):
         fp16 = resolve_bool_fp16(fp16)
         opt_level = None
         if fp16:
-            fp16.get("opt_level", None)
+            opt_level = fp16.get("opt_level", None)
 
         if opt_level is not None:
             device = "cuda"

--- a/catalyst/runners/runner.py
+++ b/catalyst/runners/runner.py
@@ -47,8 +47,11 @@ def resolve_bool_fp16(fp16: Union[Dict, bool]):
     """
     if isinstance(fp16, bool):
         if fp16:
-            return {"amp": True} if check_amp_available() \
+            return (
+                {"amp": True}
+                if check_amp_available()
                 else {"apex": True, "opt_level": "O1"}
+            )
         else:
             return {}
     else:

--- a/catalyst/runners/runner.py
+++ b/catalyst/runners/runner.py
@@ -31,7 +31,7 @@ from catalyst.utils.torch import (
 from catalyst.utils.tracing import save_traced_model, trace_model
 
 
-def resolve_bool_fp16(fp16: Union[Dict, bool]):
+def _resolve_bool_fp16(fp16: Union[Dict, bool]):
     """If fp16 is bool then converts it to dict in the following way
     If ``fp16==True``:
         * ``{"amp": True}`` if torch>=1.6.0
@@ -172,7 +172,7 @@ class Runner(IStageBasedRunner):
         """
         assert state_kwargs is None or stage_kwargs is None
 
-        fp16 = resolve_bool_fp16(fp16)
+        fp16 = _resolve_bool_fp16(fp16)
 
         if resume is not None or load_best_on_end:
             load_on_stage_end = None
@@ -270,7 +270,7 @@ class Runner(IStageBasedRunner):
         """
         assert state_kwargs is None or stage_kwargs is None
 
-        fp16 = resolve_bool_fp16(fp16)
+        fp16 = _resolve_bool_fp16(fp16)
 
         if resume is not None:
             callbacks = sort_callbacks_by_order(callbacks)
@@ -348,7 +348,7 @@ class Runner(IStageBasedRunner):
         Yields:
             bathes with model predictions
         """
-        fp16 = resolve_bool_fp16(fp16)
+        fp16 = _resolve_bool_fp16(fp16)
 
         if model is not None:
             self.model = model
@@ -425,7 +425,7 @@ class Runner(IStageBasedRunner):
             self.model = model
         assert self.model is not None
 
-        fp16 = resolve_bool_fp16(fp16)
+        fp16 = _resolve_bool_fp16(fp16)
         opt_level = None
         if fp16:
             opt_level = fp16.get("opt_level", None)

--- a/catalyst/runners/runner.py
+++ b/catalyst/runners/runner.py
@@ -47,7 +47,8 @@ def resolve_bool_fp16(fp16: Union[Dict, bool]):
     """
     if isinstance(fp16, bool):
         if fp16:
-            return {"amp": True} if check_amp_available() else {"apex": True, "opt_level": "O1"}
+            return {"amp": True} if check_amp_available() \
+                else {"apex": True, "opt_level": "O1"}
         else:
             return {}
     else:
@@ -140,7 +141,8 @@ class Runner(IStageBasedRunner):
             fp16 (Union[Dict, bool]): If not None, then sets training to FP16.
                 To use pytorch native amp: ``{"amp": True}``
                 To use apex: ``{"apex": True, "opt_level": "O1", ...}``
-                    See https://nvidia.github.io/apex/amp.html#properties for more params
+                    See https://nvidia.github.io/apex/amp.html#properties
+                    for more params
 
                 If fp16=True, params by default will be:
                     * ``{"amp": True}`` if torch>=1.6.0
@@ -421,7 +423,9 @@ class Runner(IStageBasedRunner):
         assert self.model is not None
 
         fp16 = resolve_bool_fp16(fp16)
-        opt_level = fp16.get("opt_level", None)
+        opt_level = None
+        if fp16:
+            fp16.get("opt_level", None)
 
         if opt_level is not None:
             device = "cuda"

--- a/catalyst/runners/runner.py
+++ b/catalyst/runners/runner.py
@@ -18,6 +18,7 @@ from catalyst.typing import (
     RunnerModel,
     Scheduler,
 )
+from catalyst.utils import check_amp_available
 from catalyst.utils.checkpoint import load_checkpoint, unpack_checkpoint
 from catalyst.utils.components import process_components
 from catalyst.utils.misc import maybe_recursive_call, set_global_seed
@@ -28,6 +29,29 @@ from catalyst.utils.torch import (
     set_requires_grad,
 )
 from catalyst.utils.tracing import save_traced_model, trace_model
+
+
+def resolve_bool_fp16(fp16: Union[Dict, bool]):
+    """If fp16 is bool then converts it to dict in the following way
+    If ``fp16==True``:
+        * ``{"amp": True}`` if torch>=1.6.0
+        * ``{"apex": True, "opt_level": "O1", ...}`` if torch<1.6.0
+    If ``fp16==False``:
+        * ``{}``
+    Otherwise returns fp16 unchanged
+
+    Args:
+        fp16: (Union[Dict, bool]): fp16 params
+
+    Returns: resolved version of fp16
+    """
+    if isinstance(fp16, bool):
+        if fp16:
+            return {"amp": True} if check_amp_available() else {"apex": True, "opt_level": "O1"}
+        else:
+            return {}
+    else:
+        return fp16
 
 
 class Runner(IStageBasedRunner):
@@ -114,8 +138,13 @@ class Runner(IStageBasedRunner):
             checkpoint_data: additional data to save in checkpoint,
                 for example: ``class_names``, ``date_of_training``, etc
             fp16 (Union[Dict, bool]): If not None, then sets training to FP16.
-                See https://nvidia.github.io/apex/amp.html#properties
-                if fp16=True, params by default will be ``{"opt_level": "O1"}``
+                To use pytorch native amp: ``{"amp": True}``
+                To use apex: ``{"apex": True, "opt_level": "O1", ...}``
+                    See https://nvidia.github.io/apex/amp.html#properties for more params
+
+                If fp16=True, params by default will be:
+                    * ``{"amp": True}`` if torch>=1.6.0
+                    * ``{"apex": True, "opt_level": "O1", ...}`` if torch<1.6.0
             distributed: if `True` will start training
                 in distributed mode.
                 Note: Works only with python scripts. No jupyter support.
@@ -138,8 +167,7 @@ class Runner(IStageBasedRunner):
         """
         assert state_kwargs is None or stage_kwargs is None
 
-        if isinstance(fp16, bool) and fp16:
-            fp16 = {"opt_level": "O1"}
+        fp16 = resolve_bool_fp16(fp16)
 
         if resume is not None or load_best_on_end:
             load_on_stage_end = None
@@ -223,9 +251,7 @@ class Runner(IStageBasedRunner):
             verbose: if `True`, it displays the status of the training
                 to the console.
             stage_kwargs: additional stage params
-            fp16 (Union[Dict, bool]): If not None, then sets training to FP16.
-                See https://nvidia.github.io/apex/amp.html#properties
-                if fp16=True, params by default will be ``{"opt_level": "O1"}``
+            fp16 (Union[Dict, bool]): fp16 settings (same as in `train`)
             check: if True, then only checks that pipeline is working
                 (3 epochs only)
             timeit: if True, computes the execution time
@@ -239,8 +265,7 @@ class Runner(IStageBasedRunner):
         """
         assert state_kwargs is None or stage_kwargs is None
 
-        if isinstance(fp16, bool) and fp16:
-            fp16 = {"opt_level": "O1"}
+        fp16 = resolve_bool_fp16(fp16)
 
         if resume is not None:
             callbacks = sort_callbacks_by_order(callbacks)
@@ -312,14 +337,13 @@ class Runner(IStageBasedRunner):
             loader: loader to predict
             model: model to use for prediction
             resume: path to checkpoint to resume
-            fp16 (Union[Dict, bool]): fp16 usage flag
+            fp16 (Union[Dict, bool]): fp16 settings (same as in `train`)
             initial_seed: seed to use before prediction
 
         Yields:
             bathes with model predictions
         """
-        if isinstance(fp16, bool) and fp16:
-            fp16 = {"opt_level": "O1"}
+        fp16 = resolve_bool_fp16(fp16)
 
         if model is not None:
             self.model = model
@@ -375,8 +399,7 @@ class Runner(IStageBasedRunner):
             method_name: model's method name that will be traced
             mode: ``train`` or ``eval``
             requires_grad: flag to trace with gradients
-            fp16 (Union[Dict, bool]): If not None, then sets
-                tracing params to FP16
+            fp16 (Union[Dict, bool]): fp16 settings (same as in `train`)
             device: Torch device or a string
             predict_params: additional parameters for model forward
 
@@ -397,14 +420,8 @@ class Runner(IStageBasedRunner):
             self.model = model
         assert self.model is not None
 
-        if isinstance(fp16, bool) and fp16:
-            opt_level = "O1"
-        elif isinstance(fp16, bool) and not fp16:
-            opt_level = None
-        elif isinstance(fp16, dict):
-            opt_level = fp16["opt_level"]
-        else:
-            opt_level = fp16
+        fp16 = resolve_bool_fp16(fp16)
+        opt_level = fp16.get("opt_level", None)
 
         if opt_level is not None:
             device = "cuda"

--- a/catalyst/utils/components.py
+++ b/catalyst/utils/components.py
@@ -67,7 +67,7 @@ def process_components(
         device = torch.device(device)
 
     is_apex_enabled = (
-        distributed_params.pop("apex", False) and check_apex_available()
+        distributed_params.get("apex", False) and check_apex_available()
     )
 
     is_amp_enabled = (


### PR DESCRIPTION
## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contribution guide](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md)?
- [ ] Did you check the code style? `catalyst-make-codestyle && catalyst-check-codestyle` (`pip install -U catalyst-codestyle`).
- [x] Did you make sure to update the docs? We use Google format for all the methods and classes.
- [ ] Did you check the docs with `make check-docs`?
- [ ] Did you write any new necessary tests?
- [x] Did you check that your code passes the unit tests `pytest .` ? 
- [x] Did you add your new functionality to the docs?
- [ ] Did you update the [CHANGELOG](https://github.com/catalyst-team/catalyst/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->


## Description

* Remove `AMPOptimizerCallback` and move its functionality into `OptimizerCallback`
* Change logic of `fp16=True` in `runner.train`:
```
If fp16=True, params by default will be:
    * ``{"amp": True}`` if torch>=1.6.0
    * ``{"apex": True, "opt_level": "O1", ...}`` if torch<1.6.0
```
* `OptimizerCallback` now have 2 new args: `use_amp` and `use_apex`. They can be set manually or inferred from `runner.experiment.distributed_params`
* `decouple_weight_decay` by default is now `False`
    * This change is discussible, but it seems like this is a safer assumption (for example we now have `AdamW` optimizer in PyTorch itself, which implements decoupling logic)



## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

<!-- Thank you for your contribution! -->


PS
- [x] I know, that I could [join slack](https://join.slack.com/t/catalyst-team-core/shared_invite/zt-d9miirnn-z86oKDzFMKlMG4fgFdZafw) for pull request discussion.
