### PR TITLE
SchedulerCallback: save lr and momentum only for 0-th param group

### DIFF
--- a/catalyst/callbacks/scheduler.py
+++ b/catalyst/callbacks/scheduler.py
@@ -136,6 +136,7 @@ class SchedulerCallback(ISchedulerCallback):
         momentum_list: List[Union[float, None]],
     ):
         """Update learning rate and momentum in metrics_dict
+        (consider only 0-th param group)
 
         Args:
             metrics_dict: batch_metrics or epoch_metrics
@@ -143,41 +144,25 @@ class SchedulerCallback(ISchedulerCallback):
             momentum_list: momentum for each param group
 
         """
-        if len(lr_list) == 1:
-            lr = lr_list[0]
-            momentum = momentum_list[0]
 
-            lr_key = (
-                f"lr/{self.scheduler_key}"
+        # todo: consider saving lr and momentum for all param groups ?
+        lr = lr_list[0]
+        momentum = momentum_list[0]
+
+        lr_key = (
+            f"lr/{self.scheduler_key}"
+            if self.scheduler_key is not None
+            else "lr"
+        )
+        metrics_dict[lr_key] = lr
+
+        if momentum is not None:
+            momentum_key = (
+                f"momentum/{self.scheduler_key}"
                 if self.scheduler_key is not None
-                else "lr"
+                else "momentum"
             )
-            metrics_dict[lr_key] = lr
-
-            if momentum is not None:
-                momentum_key = (
-                    f"momentum/{self.scheduler_key}"
-                    if self.scheduler_key is not None
-                    else "momentum"
-                )
-                metrics_dict[momentum_key] = momentum
-
-        else:
-            for i, (lr, momentum) in enumerate(zip(lr_list, momentum_list)):
-                lr_key = (
-                    f"lr/{self.scheduler_key}/group_{i}"
-                    if self.scheduler_key is not None
-                    else f"lr/group_{i}"
-                )
-                metrics_dict[lr_key] = lr
-
-                if momentum is not None:
-                    momentum_key = (
-                        f"momentum/{self.scheduler_key}/group_{i}"
-                        if self.scheduler_key is not None
-                        else f"momentum/group_{i}"
-                    )
-                    metrics_dict[momentum_key] = momentum
+            metrics_dict[momentum_key] = momentum
 
     def step_batch(self, runner: "IRunner") -> None:
         """Perform scheduler step and update batch metrics

--- a/catalyst/callbacks/scheduler.py
+++ b/catalyst/callbacks/scheduler.py
@@ -144,7 +144,6 @@ class SchedulerCallback(ISchedulerCallback):
             momentum_list: momentum for each param group
 
         """
-
         # todo: consider saving lr and momentum for all param groups ?
         lr = lr_list[0]
         momentum = momentum_list[0]


### PR DESCRIPTION
## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contribution guide](https://github.com/catalyst-team/catalyst/blob/master/CONTRIBUTING.md)?
- [ ] Did you check the code style? `catalyst-make-codestyle && catalyst-check-codestyle` (`pip install -U catalyst-codestyle`).
- [ ] Did you make sure to update the docs? We use Google format for all the methods and classes.
- [ ] Did you check the docs with `make check-docs`?
- [ ] Did you write any new necessary tests?
- [ ] Did you check that your code passes the unit tests `pytest .` ? 
- [ ] Did you add your new functionality to the docs?
- [ ] Did you update the [CHANGELOG](https://github.com/catalyst-team/catalyst/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->


## Description

Rollback to previous behavior
Reason:
When you have many param groups output is flooded with unnecessary info (in the vast majority of cases you don't need such functionality)
![image](https://user-images.githubusercontent.com/15240922/101650734-56516600-3a4d-11eb-9dba-2549594a1d96.png)


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->


## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

<!-- Thank you for your contribution! -->
