### PR TITLE
Bug fix to log model checkpoints as artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
--
+- Added `runner.log_artifact` to `CheckpointCallback` to log model checkpoints as artifacts to all the loggers.
 
 ### Removed
 
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
--
+- Fixed bug in the `WandbLogger.log_artifact` method.
 
 
 ## [22.02.1] - 2022-02-27

--- a/catalyst/callbacks/checkpoint.py
+++ b/catalyst/callbacks/checkpoint.py
@@ -225,6 +225,11 @@ class CheckpointCallback(ICheckpointCallback):
                     for checkpoint in self._storage
                 ]
             )
+            for checkpoint in self._storage[::-1]:
+                runner.log_artifact(
+                    tag=checkpoint.metric,
+                    path_to_artifact=checkpoint.logpath
+                )
             print(log_message)
         if self.load_best_on_end:
             self._load(runner=runner, resume_logpath=self._storage[0].logpath)

--- a/catalyst/loggers/wandb.py
+++ b/catalyst/loggers/wandb.py
@@ -113,7 +113,7 @@ class WandbLogger(ILogger):
         if artifact is None and path_to_artifact is None:
             ValueError("Both artifact and path_to_artifact cannot be None")
 
-        artifact = wandb.Artifact(
+        _artifact = wandb.Artifact(
             name=self.run.id + "_aritfacts",
             type="artifact",
             metadata={"loader_key": runner.loader_key, "scope": scope},
@@ -127,10 +127,10 @@ class WandbLogger(ILogger):
             pickle.dump(artifact, art_file)
             art_file.close()
 
-            artifact.add_file(str(os.path.join(art_file_dir, tag)))
+            _artifact.add_file(str(os.path.join(art_file_dir, tag)))
         else:
-            artifact.add_file(path_to_artifact)
-        self.run.log_artifact(artifact)
+            _artifact.add_file(path_to_artifact)
+        self.run.log_artifact(_artifact, aliases=[str(tag)])
 
     def log_image(
         self,


### PR DESCRIPTION
## Description

This PR fixes the WandbLogger.log_artifact method which was initially overwriting the provided `artifact` argument.
Moreover, in order to save models as artifacts, it adds the `runner.log_artifact` call to the `CheckpointCallback`.

## Related Issue

Fixes #1427 


## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

<!-- Thank you for your contribution! -->

### Checklist
- [ ] Have you updated tests for the new functionality?
- [ ] Have you added your new classes/functions to the docs?
- [x] Have you updated the [CHANGELOG](https://github.com/catalyst-team/catalyst/blob/master/CHANGELOG.md)?
- [ ] Have you run [colab minimal CI/CD](https://colab.research.google.com/github/catalyst-team/catalyst/blob/master/examples/notebooks/colab_ci_cd.ipynb) with `latest` requirements? Please attach the notebook link.
- [ ] Have you run [colab minimal CI/CD](https://colab.research.google.com/github/catalyst-team/catalyst/blob/master/examples/notebooks/colab_ci_cd.ipynb) with `minimal` requirements? Please attach the notebook link.
- [ ] Have you checked [XLA integration](https://colab.research.google.com/github/catalyst-team/catalyst/blob/master/examples/notebooks/XLA.ipynb)? Please attach the notebook link.
- [ ] Have you checked [distributed XLA integration](https://colab.research.google.com/github/catalyst-team/catalyst/blob/master/examples/notebooks/XLA_ddp.ipynb)? Please attach the notebook link.

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->