### PR TITLE
Fix: add comma in scikit-image versions range

### DIFF
--- a/requirements/requirements-cv.txt
+++ b/requirements/requirements-cv.txt
@@ -1,6 +1,6 @@
 imageio>=2.5.0
 opencv-python-headless>=4.2.0.32
-scikit-image<0.19.0>=0.16.1
+scikit-image<0.19.0,>=0.16.1
 torchvision>=0.5.0
 Pillow>=6.1  # torchvision fix (https://github.com/python-pillow/Pillow/issues/4130)
 requests


### PR DESCRIPTION
## Description

Correcting the absence of a comma in scikit-image versions range to comply with the [PEP440](https://peps.python.org/pep-0440/#version-specifiers)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
