### PR TITLE
kwarg fp16 doesn't exist anymore in Accelerate, replaced with mixed_precision

### DIFF
--- a/catalyst/engines/torch.py
+++ b/catalyst/engines/torch.py
@@ -40,7 +40,7 @@ class DataParallelEngine(Engine):
         """Init."""
         super().__init__(*args, cpu=False, **kwargs)
 
-    def prepare_model(self, model, device_placement, evaluation_mode):
+    def prepare_model(self, model, device_placement = None, evaluation_mode = False):
         """Overrides."""
         model = torch.nn.DataParallel(model)
         model = super().prepare_model(model, device_placement, evaluation_mode)

--- a/catalyst/engines/torch.py
+++ b/catalyst/engines/torch.py
@@ -40,10 +40,10 @@ class DataParallelEngine(Engine):
         """Init."""
         super().__init__(*args, cpu=False, **kwargs)
 
-    def prepare_model(self, model, device_placement = None, evaluation_mode = False):
+    def prepare_model(self, model, *args, **kwargs):
         """Overrides."""
         model = torch.nn.DataParallel(model)
-        model = super().prepare_model(model, device_placement, evaluation_mode)
+        model = super().prepare_model(model, *args, **kwargs)
         return model
 
 

--- a/catalyst/engines/torch.py
+++ b/catalyst/engines/torch.py
@@ -40,10 +40,10 @@ class DataParallelEngine(Engine):
         """Init."""
         super().__init__(*args, cpu=False, **kwargs)
 
-    def prepare_model(self, model):
+    def prepare_model(self, model, device_placement, evaluation_mode):
         """Overrides."""
         model = torch.nn.DataParallel(model)
-        model = super().prepare_model(model)
+        model = super().prepare_model(model, device_placement, evaluation_mode)
         return model
 
 

--- a/catalyst/runners/runner.py
+++ b/catalyst/runners/runner.py
@@ -343,9 +343,10 @@ class Runner(IRunner):
             .. _`minimal examples`: https://github.com/catalyst-team/catalyst#minimal-examples  # noqa: E501, W505
 
         """
+        mixed_precision = 'fp16' if fp16 else 'no'
         # experiment setup
         self._engine = (
-            engine or self.engine or get_available_engine(cpu=cpu, fp16=fp16, ddp=ddp)
+            engine or self.engine or get_available_engine(cpu=cpu, mixed_precision=mixed_precision, ddp=ddp)
         )
         # self._trial = trial
         self._loggers = loggers
@@ -428,7 +429,8 @@ class Runner(IRunner):
 
             .. _`minimal examples`: https://github.com/catalyst-team/catalyst#minimal-examples  # noqa: E501, W505
         """
-        self.engine = engine or get_available_engine(cpu=cpu, fp16=fp16)
+        mixed_precision = 'fp16' if fp16 else 'no'
+        self.engine = engine or get_available_engine(cpu=cpu, mixed_precision=mixed_precision)
 
         if model is not None:
             self.model = model

--- a/catalyst/utils/torch.py
+++ b/catalyst/utils/torch.py
@@ -90,7 +90,7 @@ def get_device() -> torch.device:
 
 def get_available_engine(
     cpu: bool = False,
-    fp16: bool = False,
+    mixed_precision: str = 'no',
     ddp: bool = False,
 ) -> "Engine":
     """Returns available engine based on given arguments.
@@ -98,7 +98,7 @@ def get_available_engine(
     Args:
         cpu (bool): option to use cpu for training. Default is `False`.
         ddp (bool): option to use DDP for training. Default is `False`.
-        fp16 (bool): option to use APEX for training. Default is `False`.
+        mixed_precision (str): whether or not to use mixed precision training. Default is `no`.
 
     Returns:
         Engine which match requirements.
@@ -120,11 +120,11 @@ def get_available_engine(
     is_multiple_gpus = torch.cuda.device_count() > 1
     if is_multiple_gpus:
         if ddp:
-            return DistributedDataParallelEngine(fp16=fp16)
+            return DistributedDataParallelEngine(mixed_precision=mixed_precision)
         else:
-            return DataParallelEngine(fp16=fp16)
+            return DataParallelEngine(mixed_precision=mixed_precision)
     else:
-        return GPUEngine(fp16=fp16)
+        return GPUEngine(mixed_precision=mixed_precision)
 
 
 def get_available_gpus():

--- a/requirements/requirements-cv.txt
+++ b/requirements/requirements-cv.txt
@@ -1,6 +1,6 @@
 imageio>=2.5.0
 opencv-python-headless>=4.2.0.32
-scikit-image<0.19.0>=0.16.1
+scikit-image<0.19.0,>=0.16.1
 torchvision>=0.5.0
 Pillow>=6.1  # torchvision fix (https://github.com/python-pillow/Pillow/issues/4130)
 requests


### PR DESCRIPTION
## Description

The `fp16` kwarg was replaced by `mixed_precision` in Accelerate.

I fixed also a side bug with a requirement format that would gives me this error when `pip install`: 

```
error in catalyst setup command: 'extras_require' must be a dictionary whose values are strings or lists of strings containing valid project/version requirement specifiers.
```

## Related Issue

https://github.com/catalyst-team/catalyst/issues/1440

## Type of Change

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
